### PR TITLE
fix(user): update the issue-link in feedback-drawer-sheet

### DIFF
--- a/Phonebook.Frontend/src/app/shared/directives/feedback-drawer/feedback-drawer-sheet/feedback-drawer-sheet.component.html
+++ b/Phonebook.Frontend/src/app/shared/directives/feedback-drawer/feedback-drawer-sheet/feedback-drawer-sheet.component.html
@@ -13,7 +13,7 @@
   </mat-list-item>
 
   <mat-list-item>
-    <a mat-button target="_blank" rel="noopener" href="https://github.com/T-Systems-MMS/phonebook/issues/new"
+    <a mat-button target="_blank" rel="noopener" href="https://github.com/T-Systems-MMS/phonebook/issues/new/choose"
       (click)="closeBottomSheet()">
       <img class="github-icon" alt="github" src="assets/img/GitHub-Mark-32px.png" />
       <span


### PR DESCRIPTION
Necessary that users can choose an issue template. Otherwise they will open an issue without template