### PR TITLE
fix(app): show release dialog on feature releases

### DIFF
--- a/Phonebook.Frontend/src/app/modules/table/helpers.spec.ts
+++ b/Phonebook.Frontend/src/app/modules/table/helpers.spec.ts
@@ -1,6 +1,4 @@
 import { Helpers } from './helpers';
-import { PhonebookSortDirection } from 'src/app/shared/models';
-import { VersionIncrement } from 'src/app/shared/models/enumerables/VersionIncrement';
 
 // FYI: How Compare Functions Work:
 // https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Array/sort

--- a/Phonebook.Frontend/src/app/modules/table/helpers.ts
+++ b/Phonebook.Frontend/src/app/modules/table/helpers.ts
@@ -1,5 +1,4 @@
 import { PhonebookSortDirection } from 'src/app/shared/models/enumerables/PhonebookSortDirection';
-import { VersionIncrement } from 'src/app/shared/models/enumerables/VersionIncrement';
 
 /**
  * Helper Function

--- a/Phonebook.Frontend/src/app/services/release-info.service.spec.ts
+++ b/Phonebook.Frontend/src/app/services/release-info.service.spec.ts
@@ -25,16 +25,16 @@ describe('ReleaseInfoService', () => {
 
 describe('ReleaseInfoService - whatVersionIncrement()', () => {
   it('should return major increment', () => {
-    expect(ReleaseInfoService.whatVersionIncrement('1.0.0', '2.0.0')).toEqual(VersionIncrement.major);
-    expect(ReleaseInfoService.whatVersionIncrement('1.0.0', '2.2.0')).toEqual(VersionIncrement.major);
-    expect(ReleaseInfoService.whatVersionIncrement('1.0.0', '2.2.2')).toEqual(VersionIncrement.major);
+    expect(ReleaseInfoService.whatVersionIncrement('1.0.0', '2.0.0')).toEqual(VersionIncrement.breaking);
+    expect(ReleaseInfoService.whatVersionIncrement('1.0.0', '2.2.0')).toEqual(VersionIncrement.breaking);
+    expect(ReleaseInfoService.whatVersionIncrement('1.0.0', '2.2.2')).toEqual(VersionIncrement.breaking);
   });
   it('should return minor increment', () => {
-    expect(ReleaseInfoService.whatVersionIncrement('1.0.0', '1.1.0')).toEqual(VersionIncrement.minor);
-    expect(ReleaseInfoService.whatVersionIncrement('1.0.0', '1.1.1')).toEqual(VersionIncrement.minor);
+    expect(ReleaseInfoService.whatVersionIncrement('1.0.0', '1.1.0')).toEqual(VersionIncrement.feature);
+    expect(ReleaseInfoService.whatVersionIncrement('1.0.0', '1.1.1')).toEqual(VersionIncrement.feature);
   });
   it('should return patch increment', () => {
-    expect(ReleaseInfoService.whatVersionIncrement('1.0.0', '1.0.1')).toEqual(VersionIncrement.patch);
+    expect(ReleaseInfoService.whatVersionIncrement('1.0.0', '1.0.1')).toEqual(VersionIncrement.bugfix);
   });
   it('should return no increment', () => {
     expect(ReleaseInfoService.whatVersionIncrement('1.0.0', '1.0.0')).toEqual(VersionIncrement.none);

--- a/Phonebook.Frontend/src/app/services/release-info.service.ts
+++ b/Phonebook.Frontend/src/app/services/release-info.service.ts
@@ -1,13 +1,12 @@
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
-import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatDialog, MatSnackBar } from '@angular/material';
+import { I18n } from '@ngx-translate/i18n-polyfill';
+import { Store } from '@ngxs/store';
 import { ReleaseNotificationDialog } from 'src/app/shared/dialogs/release-notification-dialog/release-notification.dialog';
 import { VersionIncrement } from 'src/app/shared/models/enumerables/VersionIncrement';
-import { Store } from '@ngxs/store';
 import { AppState, SetVersion } from 'src/app/shared/states';
 import { VERSION } from 'src/environments/version';
-import { I18n } from '@ngx-translate/i18n-polyfill';
-import { HttpClient } from '@angular/common/http';
 
 @Injectable({
   providedIn: 'root'
@@ -27,15 +26,16 @@ export class ReleaseInfoService {
       VERSION
     );
     switch (versionIncrement) {
-      case VersionIncrement.major:
+      case VersionIncrement.breaking:
         this.displayReleaseDialog();
         this.store.dispatch(new SetVersion(VERSION));
         break;
-      case VersionIncrement.minor:
+      case VersionIncrement.feature:
+        this.displayReleaseDialog();
         this.store.dispatch(new SetVersion(VERSION));
-        this.displayReleaseNotification();
         break;
-      case VersionIncrement.patch:
+      case VersionIncrement.bugfix:
+        this.displayReleaseNotification();
         this.store.dispatch(new SetVersion(VERSION));
         break;
       default:
@@ -103,15 +103,15 @@ export class ReleaseInfoService {
     const [pMajor, pMinor, pPatch] = matchedPreviousVersion.slice(1, 4);
     const [nMajor, nMinor, nPatch] = matchedNextVersion.slice(1, 4);
     if (Number(pMajor) < Number(nMajor)) {
-      return VersionIncrement.major;
+      return VersionIncrement.breaking;
     }
     if (Number(pMajor) === Number(nMajor)) {
       if (Number(pMinor) < Number(nMinor)) {
-        return VersionIncrement.minor;
+        return VersionIncrement.feature;
       }
       if (Number(pMinor) === Number(nMinor)) {
         if (Number(pPatch) < Number(nPatch)) {
-          return VersionIncrement.patch;
+          return VersionIncrement.bugfix;
         }
       }
     }

--- a/Phonebook.Frontend/src/app/shared/models/enumerables/VersionIncrement.ts
+++ b/Phonebook.Frontend/src/app/shared/models/enumerables/VersionIncrement.ts
@@ -3,9 +3,9 @@
  * major.minor.patch
  */
 export enum VersionIncrement {
-  major = 0,
-  minor = 1,
-  patch = 2,
+  breaking = 0,
+  feature = 1,
+  bugfix = 2,
   none = 3,
   malformatted = 4
 }


### PR DESCRIPTION
The Release Notification Dialog will now also be shown on feature releases instead of only on breaking changes. 