### PR TITLE
fix(table): ignore accents in search

### DIFF
--- a/Phonebook.Frontend/src/app/modules/table/helpers.spec.ts
+++ b/Phonebook.Frontend/src/app/modules/table/helpers.spec.ts
@@ -145,3 +145,11 @@ describe('Helpers - stripNonNumericalCharacters()', () => {
     ).toEqual('1234567890');
   });
 });
+
+describe('Helpers - removeAccents', () => {
+  it('remove Accents', () => {
+    expect(Helpers.removeAccents('ÀÁÂÃÄÅàáâãäåÒÓÔÕÕÖòóôõöÈÉÊËèéêëÇçÌÍÎÏìíîïÙÚÛÜùúûüÑñŠšŸÿýŽž')).toEqual(
+      'AAAAAAaaaaaaOOOOOOoooooEEEEeeeeCcIIIIiiiiUUUUuuuuNnSsYyyZz'
+    );
+  });
+});

--- a/Phonebook.Frontend/src/app/modules/table/helpers.ts
+++ b/Phonebook.Frontend/src/app/modules/table/helpers.ts
@@ -88,4 +88,12 @@ export class Helpers {
   public static stripNonNumericalCharacters(string: string): string {
     return string.replace(new RegExp('\\D', 'g'), '');
   }
+
+  /**
+   * Removes Accents from the string.
+   * @param str Any String
+   */
+  public static removeAccents(str: string): string {
+    return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  }
 }

--- a/Phonebook.Frontend/src/app/modules/table/table-logic.spec.ts
+++ b/Phonebook.Frontend/src/app/modules/table/table-logic.spec.ts
@@ -1,15 +1,15 @@
-import { TableLogic } from './table-logic';
+import { ColumnDefinitions } from 'src/app/shared/config/columnDefinitions';
 import {
-  PhonebookSortDirection,
-  PersonType,
+  Business,
+  City,
   Contacts,
   Location,
-  City,
-  Business,
-  Messenger
+  Messenger,
+  Person,
+  PersonType,
+  PhonebookSortDirection
 } from 'src/app/shared/models';
-import { Person } from 'src/app/shared/models';
-import { ColumnDefinitions } from 'src/app/shared/config/columnDefinitions';
+import { TableLogic } from './table-logic';
 
 describe('Table Logic - Sort', () => {
   it('"Axel" before "Zarathustra"', () => {
@@ -122,6 +122,92 @@ describe('Table Logic - Sort', () => {
         '',
         'Axel',
         '',
+        '',
+        '',
+        false,
+        new Contacts('', '', '', '', new Messenger('', 0)),
+        new Location(new City('', ''), []),
+        new Business([], [], [], [], [], [], '')
+      )
+    ]);
+  });
+});
+
+describe('Table Logic - Filter', () => {
+  it('Find "Mustermann"', () => {
+    const unsortedPersonsArray: Person[] = [
+      new Person(
+        PersonType.Interner_Mitarbeiter,
+        '',
+        'Mustermann',
+        'Max',
+        '',
+        '',
+        false,
+        new Contacts('', '', '', '', new Messenger('', 0)),
+        new Location(new City('', ''), []),
+        new Business([], [], [], [], [], [], '')
+      )
+    ];
+    expect(TableLogic.filter(unsortedPersonsArray, 'Mustermann', [ColumnDefinitions.fullname])).toEqual([
+      new Person(
+        PersonType.Interner_Mitarbeiter,
+        '',
+        'Mustermann',
+        'Max',
+        '',
+        '',
+        false,
+        new Contacts('', '', '', '', new Messenger('', 0)),
+        new Location(new City('', ''), []),
+        new Business([], [], [], [], [], [], '')
+      )
+    ]);
+  });
+
+  it('NOT find "Otherman"', () => {
+    const unsortedPersonsArray: Person[] = [
+      new Person(
+        PersonType.Interner_Mitarbeiter,
+        '',
+        'Mustermann',
+        'Max',
+        '',
+        '',
+        false,
+        new Contacts('', '', '', '', new Messenger('', 0)),
+        new Location(new City('', ''), []),
+        new Business([], [], [], [], [], [], '')
+      )
+    ];
+    expect(TableLogic.filter(unsortedPersonsArray, 'Otherman', [ColumnDefinitions.fullname])).toEqual([]);
+  });
+
+  it('Find Person with Diarectics', () => {
+    const unsortedPersonsArray: Person[] = [
+      new Person(
+        PersonType.Interner_Mitarbeiter,
+        '',
+        'ÀÁÂÃÄÅàáâãäåÒÓÔÕÕÖòóôõöÈÉÊËèéêëÇçÌÍÎÏìíîïÙÚÛÜùúûüÑñŠšŸÿýŽž',
+        'ÀÁÂÃÄÅàáâãäåÒÓÔÕÕÖòóôõöÈÉÊËèéêëÇçÌÍÎÏìíîïÙÚÛÜùúûüÑñŠšŸÿýŽž',
+        '',
+        '',
+        false,
+        new Contacts('', '', '', '', new Messenger('', 0)),
+        new Location(new City('', ''), []),
+        new Business([], [], [], [], [], [], '')
+      )
+    ];
+    expect(
+      TableLogic.filter(unsortedPersonsArray, 'ÀÁÂÃÄÅàáâãäåÒÓÔÕÕÖòóôõöÈÉÊËèéêëÇçÌÍÎÏìíîïÙÚÛÜùúûüÑñŠšŸÿýŽž', [
+        ColumnDefinitions.fullname
+      ])
+    ).toEqual([
+      new Person(
+        PersonType.Interner_Mitarbeiter,
+        '',
+        'ÀÁÂÃÄÅàáâãäåÒÓÔÕÕÖòóôõöÈÉÊËèéêëÇçÌÍÎÏìíîïÙÚÛÜùúûüÑñŠšŸÿýŽž',
+        'ÀÁÂÃÄÅàáâãäåÒÓÔÕÕÖòóôõöÈÉÊËèéêëÇçÌÍÎÏìíîïÙÚÛÜùúûüÑñŠšŸÿýŽž',
         '',
         '',
         false,

--- a/Phonebook.Frontend/src/app/modules/table/table-logic.ts
+++ b/Phonebook.Frontend/src/app/modules/table/table-logic.ts
@@ -1,3 +1,4 @@
+import { Helpers } from 'src/app/modules/table/helpers';
 import { ColumnDefinitions } from 'src/app/shared/config/columnDefinitions';
 import { Column } from 'src/app/shared/models';
 import { Person } from 'src/app/shared/models/classes/Person';
@@ -91,13 +92,13 @@ export class TableLogic {
 
   /**
    * Prepares the Search String by
-   * 1. Removing Commas
+   * 1. Removing Commas and accents
    * 2. Trimming whitespace
    * 3. Escaping RegEx Characters
    * @param str String to prepare
    */
   public static prepareSearchString(str: string): RegExp {
-    return TableLogic.escapeRegExp(str.replace(/,/g, '').trim());
+    return TableLogic.escapeRegExp(Helpers.removeAccents(str.trim().replace(/,/g, '')));
   }
 }
 

--- a/Phonebook.Frontend/src/app/shared/config/columnDefinitions.ts
+++ b/Phonebook.Frontend/src/app/shared/config/columnDefinitions.ts
@@ -1,9 +1,8 @@
-import { Column } from 'src/app/shared/models/interfaces';
 import { Helpers } from 'src/app/modules/table/helpers';
-import { ColumnId } from 'src/app/shared/models/enumerables/ColumnId';
 import { Person } from 'src/app/shared/models/classes/Person';
 import { PhonebookSortDirection } from 'src/app/shared/models/enumerables';
-import { ColumnTranslate } from 'src/app/shared/config/columnTranslate';
+import { ColumnId } from 'src/app/shared/models/enumerables/ColumnId';
+import { Column } from 'src/app/shared/models/interfaces';
 
 export const ColumnDefinitions: {
   picture: Readonly<Column>;
@@ -59,8 +58,9 @@ export const ColumnDefinitions: {
     fullMatchFilter: false,
     filterFunction: (filterString: RegExp, person: Person) => {
       return (
-        filterString.test(person.Title + person.Firstname + person.Surname) ||
-        filterString.test(person.Surname + person.Firstname)
+        filterString.test(
+          person.Title + Helpers.removeAccents(person.Firstname) + Helpers.removeAccents(person.Surname)
+        ) || filterString.test(Helpers.removeAccents(person.Surname) + Helpers.removeAccents(person.Firstname))
       );
     },
     sortFunction: (a: Person, b: Person, sortDirection: PhonebookSortDirection) => {

--- a/Phonebook.Frontend/src/app/shared/models/interfaces/Column.ts
+++ b/Phonebook.Frontend/src/app/shared/models/interfaces/Column.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:variable-name */
-import { Person } from '../classes/Person';
-import { PhonebookSortDirection } from 'src/app/shared/models/enumerables/PhonebookSortDirection';
 import { ColumnId } from 'src/app/shared/models/enumerables/ColumnId';
+import { PhonebookSortDirection } from 'src/app/shared/models/enumerables/PhonebookSortDirection';
+import { Person } from '../classes/Person';
 
 export interface Column {
   id: ColumnId;
@@ -12,5 +12,10 @@ export interface Column {
   sortable: boolean;
   fullMatchFilter: boolean;
   sortFunction(a: Person, b: Person, sortDirection: PhonebookSortDirection): number;
+  /**
+   * Returns true if the attribute of the person matches with the filterString.
+   * @param filterString Normalized String RegExp (with {@link TableLogic.prepareSearchString()}).
+   * @param person The Person to test.
+   */
   filterFunction(filterString: RegExp, person: Person): boolean;
 }


### PR DESCRIPTION
 - normalize string before search and remove the accents
 - also remove them in the column filter

Resolves #10