### PR TITLE
docs: allcontributors description as issue template + description in docu

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-contributors.md
+++ b/.github/ISSUE_TEMPLATE/add-contributors.md
@@ -17,4 +17,4 @@ View the types of contributions here: https://allcontributors.org/docs/en/emoji-
 
 @all-contributors please add **@username** for **contributions**
 
-<!-- The Bot will open a new PR for you. This PR will need to check by another contributor and can be merged after that. -->
+<!-- The Bot will open a new PR for you. This PR will need to be checked by another contributor and can be merged after that. -->

--- a/.github/ISSUE_TEMPLATE/add-contributors.md
+++ b/.github/ISSUE_TEMPLATE/add-contributors.md
@@ -1,0 +1,20 @@
+---
+name: Add a Contributor
+about: Add a Contributor to the project with the allcontributors-Bot
+title: 'docs: add contributor'
+labels: 'docs'
+assignees: ''
+
+---
+<!-- ---------------------- Important ---------------------- -->
+<!-- IT'S NOT NECESSARY TO OPEN A NEW ISSUE. YOU CAN ALSO CALL THE BOT IN A PULL REQUEST-->
+<!-- Only add one person per comment -->
+<!-- Use the following example -->
+
+View the types of contributions here: https://allcontributors.org/docs/en/emoji-key
+
+<!-- EXAMPLE: @all-contributors please add @mschwrdtnr for docs, code, review -->
+
+@all-contributors please add **@username** for **contributions**
+
+<!-- The Bot will open a new PR for you. This PR will need to check by another contributor and can be merged after that. -->

--- a/docs/pages/development-guides/general-guide.md
+++ b/docs/pages/development-guides/general-guide.md
@@ -36,7 +36,7 @@ This is the current project structure.
 ![npm run commit image]({{site.baseurl}}pages/development-guides/media/images/git-cz.png)
 4. Create a Pull Request from your Branch.
 5. Wait for approval from one of the maintainers.
-6. **Extra:** If you're not listed for the type of contribution you can add yourself as a contributor with the [@all-contributors-Bot](https://allcontributors.org/docs/en/overview) by writing `@all-contributors please add @username for` [specification](https://allcontributors.org/docs/en/emoji-key) in your PR.
+6. **Extra:** If you're not listed for the type of contribution you can add yourself as a contributor with the [@all-contributors-Bot](https://allcontributors.org/docs/en/overview) by writing `@all-contributors please add @username for` [specification](https://allcontributors.org/docs/en/emoji-key) in your PR as a comment.
 
 > If you need a tutorial about important git commands look [here](https://dev.to/dhruv/essential-git-commands-every-developer-should-know-2fl).
 

--- a/docs/pages/development-guides/general-guide.md
+++ b/docs/pages/development-guides/general-guide.md
@@ -42,7 +42,7 @@ This is the current project structure.
 
 ---
 
-We have splitted the development documentation in two different parts.
+We split the development documentation in two different parts.
 
 **What do you want to start with?**
 

--- a/docs/pages/development-guides/general-guide.md
+++ b/docs/pages/development-guides/general-guide.md
@@ -23,6 +23,7 @@ This is the current project structure.
    * **[Phonebook.Frontend:](frontend/general-guide)** Frontend project with all related sources
    * **Phonebook.Source.MockPeopleBackend:** Mock data source 
    * **Phonebook.Source.PeopleSoft:** One of the future data sources for the PeopleSoft application
+   * **Phonebook.Demo:** Demo Application of the Phonebook
 
 ---
 
@@ -32,16 +33,16 @@ This is the current project structure.
 2. Make some changes and develop a cool new feature or fix a Bug.
 3. In order to commit run `npm run commit` to run the interactive Commit utility.
 > We are using the angular [angular commit format reference](https://gist.github.com/brianclements/841ea7bffdb01346392c). All commits should adhere to this format in order to trigger automatic releases.
-
 ![npm run commit image]({{site.baseurl}}pages/development-guides/media/images/git-cz.png)
 4. Create a Pull Request from your Branch.
 5. Wait for approval from one of the maintainers.
+6. **Extra:** If you're not listed for the type of contribution you can add yourself as a contributor with the [@all-contributors-Bot](https://allcontributors.org/docs/en/overview) by writing `@all-contributors please add @username for` [specification](https://allcontributors.org/docs/en/emoji-key) in your PR.
 
 > If you need a tutorial about important git commands look [here](https://dev.to/dhruv/essential-git-commands-every-developer-should-know-2fl).
 
 ---
 
-We splitted the development documentation in two different parts.
+We have splitted the development documentation in two different parts.
 
 **What do you want to start with?**
 

--- a/docs/pages/development-guides/general-guide.md
+++ b/docs/pages/development-guides/general-guide.md
@@ -36,7 +36,7 @@ This is the current project structure.
 ![npm run commit image]({{site.baseurl}}pages/development-guides/media/images/git-cz.png)
 4. Create a Pull Request from your Branch.
 5. Wait for approval from one of the maintainers.
-6. **Extra:** If you're not listed for the type of contribution you can add yourself as a contributor with the [@all-contributors-Bot](https://allcontributors.org/docs/en/overview) by writing `@all-contributors please add @username for` [specification](https://allcontributors.org/docs/en/emoji-key) in your PR as a comment.
+6. **Extra:** If you're not listed for the type of contribution you can add yourself as a contributor with the [@all-contributors-Bot](https://allcontributors.org/docs/en/overview) by writing `@all-contributors please add @username for` [contribution](https://allcontributors.org/docs/en/emoji-key) in your PR as a comment.
 
 > If you need a tutorial about important git commands look [here](https://dev.to/dhruv/essential-git-commands-every-developer-should-know-2fl).
 


### PR DESCRIPTION
I don't think that it is necessary to write something about the bot into the documentation. Because of that i added a small issue-template with an usage-description.

This will closes #191.


View the example under https://github.com/mschwrdtnr/phonebook/issues/new/choose