### PR TITLE
Create node-licence-checker.yml

### DIFF
--- a/.github/workflows/node-licence-checker.yml
+++ b/.github/workflows/node-licence-checker.yml
@@ -1,0 +1,9 @@
+workflow "Scan for license issues" {
+  on = [pull_request,push]
+  resolves = ["license-checker"]
+}
+
+action "license-checker" {
+  uses = "docker://cdssnc/node-license-checker-github-action",
+  args = "--direct --onlyAllow 'MIT'"
+}


### PR DESCRIPTION
This action should check the licenses of new added dependencies. We can only allow MIT because the project is licensed under MIT.