### PR TITLE
[docs] add links to the azure devops project in the general developer documentation

### DIFF
--- a/docs/pages/development-guides/general-guide.md
+++ b/docs/pages/development-guides/general-guide.md
@@ -39,7 +39,7 @@ This is the current project structure.
 
 > If you need a tutorial about important git commands look [here](https://dev.to/dhruv/essential-git-commands-every-developer-should-know-2fl).
 
-> If you want see the CI status of your PR you can take a look at [this Azure DevOps page](https://dev.azure.com/T-Systems-MMS/phonebook/_build). There are all builds that are running. To take a look at the current release you can look at [this page](https://dev.azure.com/T-Systems-MMS/phonebook/_release). (that are only docker hub releases)
+> If you want to see the CI status of your PR you can take a look at [our Azure DevOps Page](https://dev.azure.com/T-Systems-MMS/phonebook/_build). There are all running builds. To take a look at the current release you can [view this page](https://dev.azure.com/T-Systems-MMS/phonebook/_release) (this are only docker hub releases).
 
 ---
 

--- a/docs/pages/development-guides/general-guide.md
+++ b/docs/pages/development-guides/general-guide.md
@@ -39,6 +39,8 @@ This is the current project structure.
 
 > If you need a tutorial about important git commands look [here](https://dev.to/dhruv/essential-git-commands-every-developer-should-know-2fl).
 
+> If you want see the CI status of your PR you can take a look at [this Azure DevOps page](https://dev.azure.com/T-Systems-MMS/phonebook/_build). There are all builds that are running. To take a look at the current release you can look at [this page](https://dev.azure.com/T-Systems-MMS/phonebook/_release). (that are only docker hub releases)
+
 ---
 
 We splitted the development documentation in two different parts.


### PR DESCRIPTION
Hi,

here are the documentation for the links to the azure devops stuff.