### PR TITLE
fix(bug-report-dialog): readability on small devices

### DIFF
--- a/Phonebook.Frontend/src/app/app.component.ts
+++ b/Phonebook.Frontend/src/app/app.component.ts
@@ -97,11 +97,7 @@ export class AppComponent implements OnInit {
     // Ask for Permission to send Bug reports
     const test = this.store.selectSnapshot(AppState.sendFeedback);
     if (this.store.selectSnapshot(AppState.sendFeedback) == null) {
-      const matDialogRef = this.matDialog.open(BugReportConsentComponent, {
-        maxWidth: '50vw',
-        maxHeight: '80vh',
-        hasBackdrop: true
-      });
+      const matDialogRef = this.matDialog.open(BugReportConsentComponent);
       matDialogRef.afterClosed().subscribe(consent => {
         this.store.dispatch(new SetSendFeedback(consent));
       });


### PR DESCRIPTION
resolves #182 

It works perfectly without the given arguments. There is no difference with or without `hasBackdrop`.