### PR TITLE
chore(renovate): include autolabeling and automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,11 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:nonOfficeHours",
-    ":semanticCommits"
-  ],
-  "automerge": false,
+  "extends": ["config:base", "schedule:nonOfficeHours", ":semanticCommits"],
+  "labels": ["dependencies"],
+  "automerge": true,
   "major": {
+    "automerge": false
+  },
+  "minor": {
     "automerge": false
   }
 }


### PR DESCRIPTION
I included automerge for patches and autolabeling the PR.

Maybe automerge won't work because of the secured master branch, but if GitHub or renovate fixes this issue the file is already prepared.

I think that we talk about to use https://docs.renovatebot.com/configuration-options/#automergetype in the future for patches and maybe minors. It's very annoying that renovate opens a new PR for every patch.



