### PR TITLE
fix(global-styles): Implement pb-float-right again

### DIFF
--- a/Phonebook.Frontend/src/styles.scss
+++ b/Phonebook.Frontend/src/styles.scss
@@ -154,6 +154,10 @@ app-root {
   min-height: 100%;
 }
 
+.pb-float-right {
+  float: right;
+}
+
 .pb-text-align-center {
   text-align: center;
 }


### PR DESCRIPTION
pb-float-right was removed in an earlier pr. This is need to resolve #393