### PR TITLE
fix(rooms): fix javascript error

### DIFF
--- a/Phonebook.Frontend/src/app/modules/rooms/components/room/room.component.html
+++ b/Phonebook.Frontend/src/app/modules/rooms/components/room/room.component.html
@@ -57,7 +57,7 @@
           >
             Location
           </h4>
-          <app-address mat-line [location]="{ RoomCollection: [room] }"></app-address>
+          <app-address mat-line [location]="{ RoomCollection: [room], City: {}}"></app-address>
         </mat-list-item>
         <mat-list-item *ngIf="room.Phone">
           <mat-icon mat-list-icon>phone</mat-icon>


### PR DESCRIPTION
because the location given to the address component is an artificial location the City property was missing.

introduced in #378

Can be reproduced by navigating to any room in the rooms Tab