### PR TITLE
fix(add-filter): don't display empty filter chips

### DIFF
--- a/Phonebook.Frontend/src/app/shared/components/add-filter/add-filter.component.html
+++ b/Phonebook.Frontend/src/app/shared/components/add-filter/add-filter.component.html
@@ -1,5 +1,6 @@
 <mat-chip
   propagationStop
+  *ngIf="filterValue"
   (click)="addFilter()"
   (keyup.enter)="addFilter()"
   class="pb-pointer pb-filter"


### PR DESCRIPTION
resolves #458 

filter chips will be shown only if the filterValue is neither null nor empty

testing on demo application is difficult because there are no demo datasets with incomplete (partial empty) data