### PR TITLE
feat(organigram): redesign

### DIFF
--- a/Phonebook.Frontend/src/app/modules/organigram/helpers.ts
+++ b/Phonebook.Frontend/src/app/modules/organigram/helpers.ts
@@ -1,0 +1,18 @@
+import { ParamMap } from '@angular/router';
+
+export class OrganigramHelpers {
+  public static getParamsAsArray(params: ParamMap, paramNames: string[]): string[] {
+    const paramArray: string[] = [];
+    paramNames.forEach((paramName) => {
+      const string = params.get(paramName);
+      if (string != null) {
+        paramArray.push(string);
+      }
+    });
+    return paramArray;
+  }
+
+  public static generateUrlStringFromParamArray(paramArray: string[]): string {
+    return '/organigram/' + paramArray.map((x) => x.toString().replace('/', '%2F')).join('/');
+  }
+}

--- a/Phonebook.Frontend/src/app/modules/organigram/node1/node1.component.html
+++ b/Phonebook.Frontend/src/app/modules/organigram/node1/node1.component.html
@@ -1,4 +1,4 @@
-<mat-card class="pb-margin-20">
+<mat-card class="pb-margin-20 node">
   <mat-card-title>
     <h1>
       <mat-icon
@@ -57,7 +57,7 @@
     </div>
     <div *ngIf="node?.children.length != 0">
       <mat-divider></mat-divider>
-      <h2>Children:</h2>
+      <h2 i18n="NodeComponent|SubGroups Property@@NodeComponentPropertySubGroup">Sub-Groups:</h2>
       <div class="pb-margin-20">
         <div class="pb-flex-row pb-expand">
           <mat-card

--- a/Phonebook.Frontend/src/app/modules/organigram/node1/node1.component.html
+++ b/Phonebook.Frontend/src/app/modules/organigram/node1/node1.component.html
@@ -63,6 +63,8 @@
           <mat-card
             *ngFor="let child of node?.children"
             class="pb-card pb-normal-shadow pb-margin-20"
+            (click)="navigateToChildNode(child)"
+            (keyup.enter)="navigateToChildNode(child)"
             tabindex="0"
           >
             <mat-card-header>

--- a/Phonebook.Frontend/src/app/modules/organigram/node1/node1.component.html
+++ b/Phonebook.Frontend/src/app/modules/organigram/node1/node1.component.html
@@ -1,0 +1,81 @@
+<mat-card class="pb-margin-20">
+  <mat-card-title>
+    <h1>
+      <mat-icon
+        [cdkCopyToClipboard]="getLink()"
+        (copied)="copiedToast($event)"
+        class="link pb-pointer"
+        >link</mat-icon
+      >
+      <span>{{ node?.id + ': ' + node?.name }}</span>
+    </h1>
+  </mat-card-title>
+  <mat-card-subtitle>
+    <div>
+      <span
+        i18n="
+          OrganigramNodeComponent|Supervisor Property@@OrganigramNodeComponentPropertySupervisor"
+        >{node?.supervisors.length, plural, =0 { No Supervisor } =1 { Supervisor: } other {
+        Supervisors: }}</span
+      >
+      <a *ngFor="let person of node?.supervisors" [routerLink]="['/user', person.Id]">
+        {{ person.Firstname + ' ' + person.Surname }}
+      </a>
+    </div>
+    <div>
+      <span
+        i18n="OrganigramNodeComponent|Assistant Property@@OrganigramNodeComponentPropertyAssistant"
+        >{node?.assistents.length, plural, =0 { No Assistant } =1 { Assistant: } other { Assistants:
+        }}</span
+      >
+      <a *ngFor="let person of node?.assistents" [routerLink]="['/user', person.Id]">
+        {{ person.Firstname + ' ' + person.Surname }}
+      </a>
+    </div>
+  </mat-card-subtitle>
+  <mat-card-content>
+    <div class="persons">
+      <div *ngIf="node?.employees.length > 0">
+        <h2
+          i18n="OrganigramNodeComponent|Employee Property@@OrganigramNodeComponentPropertyEmployee"
+          >{node?.employees.length, plural, =0 { No Employees } =1 { Employee: } other { Employees:
+          }}</h2
+        >
+        <li *ngFor="let person of node?.employees">
+          <a [routerLink]="['/user', person.Id]">
+            {{ person.Firstname + ' ' + person.Surname }}
+          </a>
+        </li>
+      </div>
+      <div *ngIf="node?.learners.length > 0">
+        <h2 i18n="OrganigramNodeComponent|Learners Property@@OrganigramNodeComponentPropertyLearner"
+          >{node?.learners.length, plural, =0 { No Learners } =1 { Learner: } other { Learners:
+          }}</h2
+        >
+        <li *ngFor="let person of node?.learners">
+          <a [routerLink]="['/user', person.Id]">
+            {{ person.Firstname + ' ' + person.Surname }}
+          </a>
+        </li>
+      </div>
+    </div>
+    <div *ngIf="node?.children.length != 0">
+      <mat-divider></mat-divider>
+      <h2>Children:</h2>
+      <div class="pb-margin-20">
+        <div class="pb-flex-row pb-expand">
+          <mat-card
+            *ngFor="let child of node?.children"
+            class="pb-card pb-normal-shadow pb-margin-20"
+            tabindex="0"
+          >
+            <mat-card-header>
+              <mat-card-title> {{ child.id + ': ' + child.name }} </mat-card-title>
+            </mat-card-header>
+            <mat-card-content> </mat-card-content>
+          </mat-card>
+        </div>
+      </div>
+    </div>
+  </mat-card-content>
+</mat-card>

--- a/Phonebook.Frontend/src/app/modules/organigram/node1/node1.component.html
+++ b/Phonebook.Frontend/src/app/modules/organigram/node1/node1.component.html
@@ -12,9 +12,7 @@
   </mat-card-title>
   <mat-card-subtitle>
     <div>
-      <span
-        i18n="
-          OrganigramNodeComponent|Supervisor Property@@OrganigramNodeComponentPropertySupervisor"
+      <span i18n="NodeComponent|Supervisor Property@@NodeComponentPropertySupervisor"
         >{node?.supervisors.length, plural, =0 { No Supervisor } =1 { Supervisor: } other {
         Supervisors: }}</span
       >
@@ -23,8 +21,7 @@
       </a>
     </div>
     <div>
-      <span
-        i18n="OrganigramNodeComponent|Assistant Property@@OrganigramNodeComponentPropertyAssistant"
+      <span i18n="NodeComponent|Assistant Property@@NodeComponentPropertyAssistant"
         >{node?.assistents.length, plural, =0 { No Assistant } =1 { Assistant: } other { Assistants:
         }}</span
       >
@@ -36,8 +33,7 @@
   <mat-card-content>
     <div class="persons">
       <div *ngIf="node?.employees.length > 0">
-        <h2
-          i18n="OrganigramNodeComponent|Employee Property@@OrganigramNodeComponentPropertyEmployee"
+        <h2 i18n="NodeComponent|Employee Property@@NodeComponentPropertyEmployee"
           >{node?.employees.length, plural, =0 { No Employees } =1 { Employee: } other { Employees:
           }}</h2
         >
@@ -48,7 +44,7 @@
         </li>
       </div>
       <div *ngIf="node?.learners.length > 0">
-        <h2 i18n="OrganigramNodeComponent|Learners Property@@OrganigramNodeComponentPropertyLearner"
+        <h2 i18n="NodeComponent|Learners Property@@NodeComponentPropertyLearner"
           >{node?.learners.length, plural, =0 { No Learners } =1 { Learner: } other { Learners:
           }}</h2
         >

--- a/Phonebook.Frontend/src/app/modules/organigram/node1/node1.component.scss
+++ b/Phonebook.Frontend/src/app/modules/organigram/node1/node1.component.scss
@@ -1,0 +1,29 @@
+mat-card-title {
+  display: flex;
+
+  .link {
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out;
+  }
+
+  &:hover .link {
+    opacity: 1;
+  }
+}
+
+button {
+  margin-left: auto;
+}
+
+mat-card-subtitle,
+mat-card-content {
+  margin-left: 24px;
+}
+
+.persons {
+  display: flex;
+  flex-flow: row;
+  > div {
+    flex: 1;
+  }
+}

--- a/Phonebook.Frontend/src/app/modules/organigram/node1/node1.component.scss
+++ b/Phonebook.Frontend/src/app/modules/organigram/node1/node1.component.scss
@@ -27,3 +27,7 @@ mat-card-content {
     flex: 1;
   }
 }
+
+.node {
+  margin-left: 40px;
+}

--- a/Phonebook.Frontend/src/app/modules/organigram/node1/node1.component.ts
+++ b/Phonebook.Frontend/src/app/modules/organigram/node1/node1.component.ts
@@ -4,7 +4,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { RoomHelpers } from 'src/app/modules/rooms/helpers';
 import { BuildingService } from 'src/app/services/api/building.service';
-import { BuildingTreeNode, RoomService } from 'src/app/services/api/room.service';
 import { Location } from 'src/app/shared/models';
 import { RuntimeEnvironmentInterface } from 'src/environments/EnvironmentInterfaces';
 import { runtimeEnvironment } from 'src/environments/runtime-environment';

--- a/Phonebook.Frontend/src/app/modules/organigram/node1/node1.component.ts
+++ b/Phonebook.Frontend/src/app/modules/organigram/node1/node1.component.ts
@@ -1,0 +1,110 @@
+import { Component, OnInit } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { RoomHelpers } from 'src/app/modules/rooms/helpers';
+import { BuildingService } from 'src/app/services/api/building.service';
+import { BuildingTreeNode, RoomService } from 'src/app/services/api/room.service';
+import { Location } from 'src/app/shared/models';
+import { RuntimeEnvironmentInterface } from 'src/environments/EnvironmentInterfaces';
+import { runtimeEnvironment } from 'src/environments/runtime-environment';
+import { OrganigramHelpers } from 'src/app/modules/organigram/helpers';
+import { OrganigramService, UnitTreeNode } from 'src/app/services/api/organigram.service';
+import { Navigate, RouterState } from '@ngxs/router-plugin';
+import { WindowRef } from 'src/app/services/windowRef.service';
+import { Store } from '@ngxs/store';
+
+@Component({
+  selector: 'app-node1',
+  templateUrl: './node1.component.html',
+  styleUrls: ['./node1.component.scss'],
+  host: { class: 'pb-height-expand' },
+})
+export class Node1Component implements OnInit {
+  public node: UnitTreeNode;
+  public locations: Location[];
+  public runtimeEnvironment: RuntimeEnvironmentInterface = runtimeEnvironment;
+
+  constructor(
+    private route: ActivatedRoute,
+    private organigramService: OrganigramService,
+    private router: Router,
+    private windowRef: WindowRef,
+    private snackBar: MatSnackBar,
+    private store: Store,
+    private buildingService: BuildingService
+  ) {}
+
+  public ngOnInit() {
+    this.route.paramMap.subscribe((params) => {
+      this.organigramService
+        .getNodeByPath(
+          OrganigramHelpers.getParamsAsArray(params, ['node1Id', 'buildingId', 'floorId', 'roomId'])
+        )
+        .subscribe((node) => {
+          if (node == null) {
+            this.snackBar.open(
+              $localize`:CityComponent|Error Message if City does not exist.@@CityComponentErrorNoCity:City does not exist.`,
+              '',
+              { duration: 5000 }
+            );
+            this.router.navigate(['/organigram']);
+          } else {
+            this.node = node;
+            this.buildingService.getByCity(this.node.name).subscribe((locations) => {
+              this.locations = locations;
+            });
+          }
+        });
+    });
+  }
+
+  public getLink() {
+    return this.windowRef.getCurrentUrl();
+  }
+  public generatePath(withNode: boolean): string[] {
+    // Get the Path till the depth of the node
+    let path = this.getCurrentRouteAsArray().slice(0, this.node.depth + 1);
+    //
+    if (withNode) {
+      path = [...path, this.node.id];
+    }
+    return path;
+  }
+
+  public copiedToast(success: boolean) {
+    if (success) {
+      this.store.dispatch(new Navigate(this.generatePath(true)));
+      this.snackBar.open(
+        $localize`:OrganigramNodeComponent|First part of the message displayed when copying a link to the node@@OrganigramNodeComponentCopiedFirstPart:Link to` +
+          ' "' +
+          this.node.name +
+          '" ' +
+          $localize`:OrganigramNodeComponent|Second part of the message displayed when copying a link to the node@@OrganigramNodeComponentCopiedSecondPart:copied to clipboard!`,
+        '',
+        { duration: 2000 }
+      );
+    } else {
+      this.snackBar.open(
+        $localize`:GeneralErrorMessageCopy|Message displayed when copying something went wrong@@GeneralErrorMessageCopy:Couldn't copy to the clipboard, something went wrong. Try again.`,
+        '',
+        { duration: 2000 }
+      );
+    }
+  }
+  public getCurrentRouteAsArray(): string[] {
+    const navState = this.store.selectSnapshot(RouterState.state);
+    return [
+      navState!.root.firstChild!.url[0].path,
+      ...navState!.root.firstChild!.firstChild!.url.map((obj) => {
+        return obj.path;
+      }),
+    ];
+  }
+
+  public navigateToBuilding(building: string) {
+    this.router.navigateByUrl(
+      RoomHelpers.generateUrlStringFromParamArray([...this.node!.name, building])
+    );
+  }
+}

--- a/Phonebook.Frontend/src/app/modules/organigram/node1/node1.component.ts
+++ b/Phonebook.Frontend/src/app/modules/organigram/node1/node1.component.ts
@@ -2,9 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute, Router } from '@angular/router';
 
-import { RoomHelpers } from 'src/app/modules/rooms/helpers';
-import { BuildingService } from 'src/app/services/api/building.service';
-import { Location } from 'src/app/shared/models';
 import { RuntimeEnvironmentInterface } from 'src/environments/EnvironmentInterfaces';
 import { runtimeEnvironment } from 'src/environments/runtime-environment';
 import { OrganigramHelpers } from 'src/app/modules/organigram/helpers';
@@ -21,7 +18,6 @@ import { Store } from '@ngxs/store';
 })
 export class Node1Component implements OnInit {
   public node: UnitTreeNode;
-  public locations: Location[];
   public runtimeEnvironment: RuntimeEnvironmentInterface = runtimeEnvironment;
 
   constructor(
@@ -30,29 +26,25 @@ export class Node1Component implements OnInit {
     private router: Router,
     private windowRef: WindowRef,
     private snackBar: MatSnackBar,
-    private store: Store,
-    private buildingService: BuildingService
+    private store: Store
   ) {}
 
   public ngOnInit() {
     this.route.paramMap.subscribe((params) => {
       this.organigramService
         .getNodeByPath(
-          OrganigramHelpers.getParamsAsArray(params, ['node1Id', 'buildingId', 'floorId', 'roomId'])
+          OrganigramHelpers.getParamsAsArray(params, ['node1Id', 'node2Id', 'node3Id'])
         )
         .subscribe((node) => {
           if (node == null) {
             this.snackBar.open(
-              $localize`:CityComponent|Error Message if City does not exist.@@CityComponentErrorNoCity:City does not exist.`,
+              $localize`:NodeComponent|Error Message if Node does not exist.@@NodeComponentErrorNoNode:Organisation does not exist.`,
               '',
               { duration: 5000 }
             );
             this.router.navigate(['/organigram']);
           } else {
             this.node = node;
-            this.buildingService.getByCity(this.node.name).subscribe((locations) => {
-              this.locations = locations;
-            });
           }
         });
     });
@@ -75,11 +67,11 @@ export class Node1Component implements OnInit {
     if (success) {
       this.store.dispatch(new Navigate(this.generatePath(true)));
       this.snackBar.open(
-        $localize`:OrganigramNodeComponent|First part of the message displayed when copying a link to the node@@OrganigramNodeComponentCopiedFirstPart:Link to` +
+        $localize`:NodeComponent|First part of the message displayed when copying a link to the node@@NodeComponentCopiedFirstPart:Link to` +
           ' "' +
           this.node.name +
           '" ' +
-          $localize`:OrganigramNodeComponent|Second part of the message displayed when copying a link to the node@@OrganigramNodeComponentCopiedSecondPart:copied to clipboard!`,
+          $localize`:NodeComponent|Second part of the message displayed when copying a link to the node@@NodeComponentCopiedSecondPart:copied to clipboard!`,
         '',
         { duration: 2000 }
       );
@@ -101,9 +93,9 @@ export class Node1Component implements OnInit {
     ];
   }
 
-  public navigateToBuilding(building: string) {
+  public navigateToChildNode(child: UnitTreeNode) {
     this.router.navigateByUrl(
-      RoomHelpers.generateUrlStringFromParamArray([...this.node!.name, building])
+      OrganigramHelpers.generateUrlStringFromParamArray([...this.node!.name, child.name])
     );
   }
 }

--- a/Phonebook.Frontend/src/app/modules/organigram/organigram-routing.module.ts
+++ b/Phonebook.Frontend/src/app/modules/organigram/organigram-routing.module.ts
@@ -12,6 +12,7 @@ const routes: Routes = [
     children: [
       { path: '', component: OrganigramOverviewComponent, pathMatch: 'full' },
       { path: ':node1Id', component: Node1Component },
+      { path: ':node1Id/:node2Id', component: Node1Component },
     ],
   },
   { path: '**', redirectTo: '' },

--- a/Phonebook.Frontend/src/app/modules/organigram/organigram-routing.module.ts
+++ b/Phonebook.Frontend/src/app/modules/organigram/organigram-routing.module.ts
@@ -2,12 +2,17 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { OrganigramComponent } from 'src/app/modules/organigram/pages/organigram/organigram.component';
 import { OrganigramOverviewComponent } from 'src/app/modules/organigram/overview/organigram-overview.component';
+import { OrganigramNodeComponent } from 'src/app/modules/organigram/components/organigram-node/organigram-node.component';
+import { Node1Component } from 'src/app/modules/organigram/node1/node1.component';
 
 const routes: Routes = [
   {
     path: '',
     component: OrganigramComponent,
-    children: [{ path: '', component: OrganigramOverviewComponent, pathMatch: 'full' }],
+    children: [
+      { path: '', component: OrganigramOverviewComponent, pathMatch: 'full' },
+      { path: ':node1Id', component: Node1Component },
+    ],
   },
   { path: '**', redirectTo: '' },
 ];

--- a/Phonebook.Frontend/src/app/modules/organigram/organigram-routing.module.ts
+++ b/Phonebook.Frontend/src/app/modules/organigram/organigram-routing.module.ts
@@ -1,14 +1,15 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { OrganigramComponent } from 'src/app/modules/organigram/pages/organigram/organigram.component';
+import { OrganigramOverviewComponent } from 'src/app/modules/organigram/overview/organigram-overview.component';
 
 const routes: Routes = [
-  { path: '', component: OrganigramComponent, pathMatch: 'full' },
-  { path: ':first', component: OrganigramComponent },
-  { path: ':first/:second', component: OrganigramComponent },
-  { path: ':first/:second/:third', component: OrganigramComponent },
-  { path: ':first/:second/:third/:fourth', component: OrganigramComponent },
-  { path: ':first/:second/:third/:fourth/:fifth', component: OrganigramComponent },
+  {
+    path: '',
+    component: OrganigramComponent,
+    children: [{ path: '', component: OrganigramOverviewComponent, pathMatch: 'full' }],
+  },
+  { path: '**', redirectTo: '' },
 ];
 
 @NgModule({

--- a/Phonebook.Frontend/src/app/modules/organigram/organigram-routing.module.ts
+++ b/Phonebook.Frontend/src/app/modules/organigram/organigram-routing.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { OrganigramComponent } from 'src/app/modules/organigram/pages/organigram/organigram.component';
 import { OrganigramOverviewComponent } from 'src/app/modules/organigram/overview/organigram-overview.component';
-import { OrganigramNodeComponent } from 'src/app/modules/organigram/components/organigram-node/organigram-node.component';
 import { Node1Component } from 'src/app/modules/organigram/node1/node1.component';
 
 const routes: Routes = [
@@ -13,6 +12,7 @@ const routes: Routes = [
       { path: '', component: OrganigramOverviewComponent, pathMatch: 'full' },
       { path: ':node1Id', component: Node1Component },
       { path: ':node1Id/:node2Id', component: Node1Component },
+      { path: ':node1Id/:node2Id/:node3Id', component: Node1Component },
     ],
   },
   { path: '**', redirectTo: '' },

--- a/Phonebook.Frontend/src/app/modules/organigram/organigram.module.ts
+++ b/Phonebook.Frontend/src/app/modules/organigram/organigram.module.ts
@@ -9,7 +9,8 @@ import { ClipboardModule } from '@angular/cdk/clipboard';
 import { OrganigramNodeComponent } from 'src/app/modules/organigram/components/organigram-node/organigram-node.component';
 import { OrganigramRoutingModule } from 'src/app/modules/organigram/organigram-routing.module';
 import { OrganigramComponent } from 'src/app/modules/organigram/pages/organigram/organigram.component';
-
+import { MaterialModule } from 'src/app/shared/material.module';
+import { OrganigramOverviewComponent } from 'src/app/modules/organigram/overview/organigram-overview.component';
 @NgModule({
   imports: [
     CommonModule,
@@ -20,8 +21,9 @@ import { OrganigramComponent } from 'src/app/modules/organigram/pages/organigram
     ClipboardModule,
     MatButtonModule,
     MatTooltipModule,
+    MaterialModule,
   ],
-  declarations: [OrganigramComponent, OrganigramNodeComponent],
+  declarations: [OrganigramComponent, OrganigramNodeComponent, OrganigramOverviewComponent],
   exports: [],
 })
 export class OrganigramModule {}

--- a/Phonebook.Frontend/src/app/modules/organigram/organigram.module.ts
+++ b/Phonebook.Frontend/src/app/modules/organigram/organigram.module.ts
@@ -11,6 +11,9 @@ import { OrganigramRoutingModule } from 'src/app/modules/organigram/organigram-r
 import { OrganigramComponent } from 'src/app/modules/organigram/pages/organigram/organigram.component';
 import { MaterialModule } from 'src/app/shared/material.module';
 import { OrganigramOverviewComponent } from 'src/app/modules/organigram/overview/organigram-overview.component';
+import { Node1Component } from 'src/app/modules/organigram/node1/node1.component';
+import { AddressModule } from 'src/app/shared/components/address/address.module';
+
 @NgModule({
   imports: [
     CommonModule,
@@ -22,8 +25,14 @@ import { OrganigramOverviewComponent } from 'src/app/modules/organigram/overview
     MatButtonModule,
     MatTooltipModule,
     MaterialModule,
+    AddressModule,
   ],
-  declarations: [OrganigramComponent, OrganigramNodeComponent, OrganigramOverviewComponent],
+  declarations: [
+    OrganigramComponent,
+    OrganigramNodeComponent,
+    OrganigramOverviewComponent,
+    Node1Component,
+  ],
   exports: [],
 })
 export class OrganigramModule {}

--- a/Phonebook.Frontend/src/app/modules/organigram/overview/organigram-overview.component.html
+++ b/Phonebook.Frontend/src/app/modules/organigram/overview/organigram-overview.component.html
@@ -1,0 +1,16 @@
+<div class="pb-margin-20">
+  <div class="pb-flex-row pb-expand">
+    <mat-card
+      *ngFor="let node of nodes"
+      class="pb-card pb-normal-shadow pb-margin-20"
+      (click)="navigateToCity(node)"
+      (keyup.enter)="navigateToCity(node)"
+      tabindex="0"
+    >
+      <mat-card-header>
+        <mat-card-title> {{ node.id + ': ' + node.name }} </mat-card-title>
+      </mat-card-header>
+      <mat-card-content> </mat-card-content>
+    </mat-card>
+  </div>
+</div>

--- a/Phonebook.Frontend/src/app/modules/organigram/overview/organigram-overview.component.html
+++ b/Phonebook.Frontend/src/app/modules/organigram/overview/organigram-overview.component.html
@@ -3,8 +3,8 @@
     <mat-card
       *ngFor="let node of nodes"
       class="pb-card pb-normal-shadow pb-margin-20"
-      (click)="navigateToCity(node)"
-      (keyup.enter)="navigateToCity(node)"
+      (click)="navigateToFirstNode(node)"
+      (keyup.enter)="navigateToFirstNode(node)"
       tabindex="0"
     >
       <mat-card-header>

--- a/Phonebook.Frontend/src/app/modules/organigram/overview/organigram-overview.component.ts
+++ b/Phonebook.Frontend/src/app/modules/organigram/overview/organigram-overview.component.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { RoomHelpers } from 'src/app/modules/rooms/helpers';
 import { BuildingTreeNode, RoomService } from 'src/app/services/api/room.service';
 import { OrganigramService, UnitTreeNode } from 'src/app/services/api/organigram.service';
+import { OrganigramHelpers } from 'src/app/modules/organigram/helpers';
 
 @Component({
   selector: 'app-organigram-overview',
@@ -20,7 +21,7 @@ export class OrganigramOverviewComponent implements OnInit {
     });
   }
 
-  public navigateToCity(city: BuildingTreeNode) {
-    this.router.navigateByUrl(RoomHelpers.generateUrlStringFromParamArray([city.name]));
+  public navigateToFirstNode(node1: UnitTreeNode) {
+    this.router.navigateByUrl(OrganigramHelpers.generateUrlStringFromParamArray([node1.name]));
   }
 }

--- a/Phonebook.Frontend/src/app/modules/organigram/overview/organigram-overview.component.ts
+++ b/Phonebook.Frontend/src/app/modules/organigram/overview/organigram-overview.component.ts
@@ -1,7 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { RoomHelpers } from 'src/app/modules/rooms/helpers';
-import { BuildingTreeNode, RoomService } from 'src/app/services/api/room.service';
 import { OrganigramService, UnitTreeNode } from 'src/app/services/api/organigram.service';
 import { OrganigramHelpers } from 'src/app/modules/organigram/helpers';
 

--- a/Phonebook.Frontend/src/app/modules/organigram/overview/organigram-overview.component.ts
+++ b/Phonebook.Frontend/src/app/modules/organigram/overview/organigram-overview.component.ts
@@ -1,0 +1,26 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { RoomHelpers } from 'src/app/modules/rooms/helpers';
+import { BuildingTreeNode, RoomService } from 'src/app/services/api/room.service';
+import { OrganigramService, UnitTreeNode } from 'src/app/services/api/organigram.service';
+
+@Component({
+  selector: 'app-organigram-overview',
+  templateUrl: './organigram-overview.component.html',
+  styleUrls: ['./organigram-overview.component.scss'],
+})
+export class OrganigramOverviewComponent implements OnInit {
+  public nodes: UnitTreeNode[] = [];
+
+  constructor(private organigramService: OrganigramService, private router: Router) {}
+
+  public ngOnInit() {
+    this.organigramService.getOrganigram().subscribe((organigram) => {
+      this.nodes = organigram;
+    });
+  }
+
+  public navigateToCity(city: BuildingTreeNode) {
+    this.router.navigateByUrl(RoomHelpers.generateUrlStringFromParamArray([city.name]));
+  }
+}

--- a/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.html
+++ b/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.html
@@ -14,16 +14,14 @@
     {{ node }}
   </button>
   <a
+    *ngIf="currentUser != null"
     mat-button
-    *ngIf="myOrganigramUrl"
     class="btn-whereAmI"
-    target="_blank"
-    rel="noopener"
-    [href]="myOrganigramUrl"
+    (click)="navigateToUsersOrganigram()"
   >
-    <mat-icon>people</mat-icon>
+    <mat-icon>business</mat-icon>
     <span
-      i18n="OrganigramComponent|Button for going to user's organigram@@OrganigramComponentWhoAmI"
+      i18n="OrganigramComponent|Button for going to user's organigram@@OrganigramComponentWhereAmI"
     >
       Where am I?
     </span>
@@ -39,8 +37,7 @@
           tabindex="0"
           (click)="navigateToNodePath(node)"
           (keyup.enter)="navigateToNodePath(node)"
-          ><button mat-icon-button disabled matTreeNodeToggle
-            ><mat-icon>desktop_mac</mat-icon></button
+          ><button mat-icon-button disabled matTreeNodeToggle><mat-icon>business</mat-icon></button
           ><div>{{ node.id + ': ' + node.name }}</div></li
         ></mat-tree-node
       ><mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
@@ -77,7 +74,7 @@
         <mat-icon>{{ drawer.opened ? 'chevron_left' : 'chevron_right' }} </mat-icon>
       </button>
     </div>
-    <div class="pb-expand pb-overflow-auto router-outlet">
+    <div class="pb-expand pb-overflow-auto">
       <router-outlet></router-outlet>
     </div>
   </mat-drawer-content>

--- a/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.html
+++ b/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.html
@@ -15,13 +15,9 @@
       >Overview</span
     >
   </button>
-  <button
-    mat-button
-    *ngFor="let param of params; let i = index"
-    (click)="navigateToNodePath(params.slice(0, i + 1))"
-  >
+  <button mat-button *ngFor="let node of params; let i = index" (click)="navigateToNodePath(node)">
     <mat-icon>chevron_right</mat-icon>
-    {{ param }}
+    {{ node }}
   </button>
   <a
     mat-button

--- a/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.html
+++ b/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.html
@@ -1,9 +1,3 @@
-<!--<div id="pb-organigram">
-  <ng-container *ngFor="let node of nodes">
-    <app-organigram-node [node]="node" class="node"> </app-organigram-node>
-  </ng-container>
-</div>-->
-
 <mat-toolbar>
   <button mat-icon-button [routerLink]="['/organigram']" *ngIf="params.length != 0">
     <mat-icon>location_on</mat-icon>
@@ -11,7 +5,7 @@
   <button mat-button [routerLink]="['/organigram']" *ngIf="params.length === 0">
     <mat-icon>location_on</mat-icon>
     <span
-      i18n="Room-treeComponent|Root of the Navigation Tree@@RoomTreeComponentRootNavigationTitle"
+      i18n="OrganigramComponent|Root of the Organigram Tree@@OrganigramComponentRootNavigationTitle"
       >Overview</span
     >
   </button>
@@ -29,9 +23,7 @@
   >
     <mat-icon>people</mat-icon>
     <span
-      i18n="
-        RoomTreeComponent|Button for changing to the booking
-        tool@@RoomTreeComponentButtonBookingTool"
+      i18n="OrganigramComponent|Button for going to user's organigram@@OrganigramComponentWhoAmI"
     >
       Where am I?
     </span>
@@ -74,11 +66,11 @@
         mat-icon-button
         (click)="drawer.toggle()"
         i18n-matTooltip="
-          RoomTreeComponent|Tooltip for expanding the tree
-          view@@RoomTreeComponentButtonExpandTooltip"
+          OrganigramComponent|Tooltip for expanding the tree
+          view@@OrganigramComponentButtonExpandTooltip"
         i18n-aria-label="
-          RoomTreeComponent|Aria Label for expanding the tree
-          view@@RoomTreeComponentButtonExpandAriaLabel"
+          OrganigramComponent|Aria Label for expanding the tree
+          view@@OrganigramComponentButtonExpandAriaLabel"
         aria-label="Button expanding or collapsing the tree view on the left."
         matTooltip="Expand or Collapse the tree view."
       >

--- a/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.html
+++ b/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.html
@@ -1,5 +1,75 @@
-<div id="pb-organigram">
+<!--<div id="pb-organigram">
   <ng-container *ngFor="let node of nodes">
     <app-organigram-node [node]="node" class="node"> </app-organigram-node>
   </ng-container>
-</div>
+</div>-->
+
+<mat-toolbar>
+  <button mat-icon-button [routerLink]="['/organigram']">
+    <mat-icon>location_on</mat-icon>
+  </button>
+  <button mat-button [routerLink]="['/organigram']">
+    <mat-icon>location_on</mat-icon>
+    <span
+      i18n="Room-treeComponent|Root of the Navigation Tree@@RoomTreeComponentRootNavigationTitle"
+      >Overview</span
+    >
+  </button>
+  <button mat-button>
+    <mat-icon>chevron_right</mat-icon>
+    <ng-container i18n="@@DataPersonFloor">Floor</ng-container>
+  </button>
+</mat-toolbar>
+<mat-drawer-container hasBackdrop="false" class="pb-flex-1">
+  <mat-drawer #drawer mode="side" class="tree-drawer" [opened]="drawerOpenByDefault">
+    <mat-tree [dataSource]="dataSource" [treeControl]="treeControl" class="location-tree"
+      ><mat-tree-node *matTreeNodeDef="let node"
+        ><li
+          class="mat-tree-node"
+          matRipple
+          tabindex="0"
+          (click)="navigateToNodePath(node.path)"
+          (keyup.enter)="navigateToNodePath(node.path)"
+          ><button mat-icon-button disabled matTreeNodeToggle
+            ><mat-icon>meeting_room</mat-icon></button
+          ><div>{{ node.id + ': ' + node.name }}</div></li
+        ></mat-tree-node
+      ><mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
+        <li>
+          <div class="mat-tree-node" matRipple (click)="navigateToNodePath(node.path)"
+            ><button
+              mat-icon-button
+              matTreeNodeToggle
+              [attr.aria-label]="'toggle ' + node.name"
+              (click)="navigateToNodePath(node.path)"
+              ><mat-icon>
+                {{ treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right' }}</mat-icon
+              ></button
+            ><div> {{ node.name }}</div></div
+          ><ul *ngIf="treeControl.isExpanded(node)"
+            ><ng-container matTreeNodeOutlet></ng-container
+          ></ul>
+        </li> </mat-nested-tree-node></mat-tree
+  ></mat-drawer>
+  <mat-drawer-content>
+    <div class="toggle-drawer">
+      <button
+        mat-icon-button
+        (click)="drawer.toggle()"
+        i18n-matTooltip="
+          RoomTreeComponent|Tooltip for expanding the tree
+          view@@RoomTreeComponentButtonExpandTooltip"
+        i18n-aria-label="
+          RoomTreeComponent|Aria Label for expanding the tree
+          view@@RoomTreeComponentButtonExpandAriaLabel"
+        aria-label="Button expanding or collapsing the tree view on the left."
+        matTooltip="Expand or Collapse the tree view."
+      >
+        <mat-icon>{{ drawer.opened ? 'chevron_left' : 'chevron_right' }} </mat-icon>
+      </button>
+    </div>
+    <div class="pb-expand pb-overflow-auto">
+      <router-outlet></router-outlet>
+    </div>
+  </mat-drawer-content>
+</mat-drawer-container>

--- a/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.html
+++ b/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.html
@@ -5,20 +5,41 @@
 </div>-->
 
 <mat-toolbar>
-  <button mat-icon-button [routerLink]="['/organigram']">
+  <button mat-icon-button [routerLink]="['/organigram']" *ngIf="params.length != 0">
     <mat-icon>location_on</mat-icon>
   </button>
-  <button mat-button [routerLink]="['/organigram']">
+  <button mat-button [routerLink]="['/organigram']" *ngIf="params.length === 0">
     <mat-icon>location_on</mat-icon>
     <span
       i18n="Room-treeComponent|Root of the Navigation Tree@@RoomTreeComponentRootNavigationTitle"
       >Overview</span
     >
   </button>
-  <button mat-button>
+  <button
+    mat-button
+    *ngFor="let param of params; let i = index"
+    (click)="navigateToNodePath(params.slice(0, i + 1))"
+  >
     <mat-icon>chevron_right</mat-icon>
-    <ng-container i18n="@@DataPersonFloor">Floor</ng-container>
+    {{ param }}
   </button>
+  <a
+    mat-button
+    *ngIf="myOrganigramUrl"
+    class="btn-whereAmI"
+    target="_blank"
+    rel="noopener"
+    [href]="myOrganigramUrl"
+  >
+    <mat-icon>people</mat-icon>
+    <span
+      i18n="
+        RoomTreeComponent|Button for changing to the booking
+        tool@@RoomTreeComponentButtonBookingTool"
+    >
+      Where am I?
+    </span>
+  </a>
 </mat-toolbar>
 <mat-drawer-container hasBackdrop="false" class="pb-flex-1">
   <mat-drawer #drawer mode="side" class="tree-drawer" [opened]="drawerOpenByDefault">
@@ -28,20 +49,20 @@
           class="mat-tree-node"
           matRipple
           tabindex="0"
-          (click)="navigateToNodePath(node.path)"
-          (keyup.enter)="navigateToNodePath(node.path)"
+          (click)="navigateToNodePath(node)"
+          (keyup.enter)="navigateToNodePath(node)"
           ><button mat-icon-button disabled matTreeNodeToggle
-            ><mat-icon>meeting_room</mat-icon></button
+            ><mat-icon>desktop_mac</mat-icon></button
           ><div>{{ node.id + ': ' + node.name }}</div></li
         ></mat-tree-node
       ><mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
         <li>
-          <div class="mat-tree-node" matRipple (click)="navigateToNodePath(node.path)"
+          <div class="mat-tree-node" matRipple (click)="navigateToNodePath(node)"
             ><button
               mat-icon-button
               matTreeNodeToggle
               [attr.aria-label]="'toggle ' + node.name"
-              (click)="navigateToNodePath(node.path)"
+              (click)="navigateToNodePath(node)"
               ><mat-icon>
                 {{ treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right' }}</mat-icon
               ></button
@@ -68,7 +89,7 @@
         <mat-icon>{{ drawer.opened ? 'chevron_left' : 'chevron_right' }} </mat-icon>
       </button>
     </div>
-    <div class="pb-expand pb-overflow-auto">
+    <div class="pb-expand pb-overflow-auto router-outlet">
       <router-outlet></router-outlet>
     </div>
   </mat-drawer-content>

--- a/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.scss
+++ b/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.scss
@@ -1,10 +1,28 @@
-.node {
-  margin: 20px 40px;
+.tree-drawer {
+  width: 400px;
+  height: 100%;
 }
 
-#pb-organigram {
-  width: 100%;
-  display: flex;
+.toggle-drawer {
   height: 100%;
-  flex-direction: column;
+  display: flex;
+  position: absolute;
+  z-index: 1;
+
+  button {
+    align-self: center;
+  }
+}
+
+.btn-booking {
+  margin-left: auto;
+}
+
+.location-tree {
+  ul,
+  li {
+    margin-top: 0;
+    margin-bottom: 0;
+    list-style-type: none;
+  }
 }

--- a/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.scss
+++ b/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.scss
@@ -26,7 +26,3 @@
     list-style-type: none;
   }
 }
-
-.router-outlet {
-  margin-left: 20px;
-}

--- a/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.scss
+++ b/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.scss
@@ -14,7 +14,7 @@
   }
 }
 
-.btn-booking {
+.btn-whereAmI {
   margin-left: auto;
 }
 
@@ -25,4 +25,8 @@
     margin-bottom: 0;
     list-style-type: none;
   }
+}
+
+.router-outlet {
+  margin-left: 20px;
 }

--- a/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.ts
+++ b/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.ts
@@ -1,20 +1,87 @@
 import { Component, OnInit } from '@angular/core';
+import { untilComponentDestroyed } from 'ng2-rx-componentdestroyed';
+import { of } from 'rxjs';
+import { BreakpointObserver } from '@angular/cdk/layout';
 import { OrganigramService, UnitTreeNode } from 'src/app/services/api/organigram.service';
+import { MatTreeNestedDataSource } from '@angular/material/tree';
+import { NestedTreeControl } from '@angular/cdk/tree';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { OrganigramHelpers } from 'src/app/modules/organigram/helpers';
+import { filter, switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-organigram',
   templateUrl: './organigram.component.html',
   styleUrls: ['./organigram.component.scss'],
-  host: { class: 'pb-expand' },
+  host: { class: 'pb-fill-parent pb-flex-column' },
 })
 export class OrganigramComponent implements OnInit {
+  public params: string[] = [];
   public nodes: UnitTreeNode[] = [];
+  public drawerOpenByDefault: boolean = false;
+  public dataSource: MatTreeNestedDataSource<UnitTreeNode>;
+  public treeControl: NestedTreeControl<UnitTreeNode>;
 
-  constructor(private organigramService: OrganigramService) {}
+  constructor(
+    private organigramService: OrganigramService,
+    private route: ActivatedRoute,
+    private router: Router,
+    private breakpointObserver: BreakpointObserver
+  ) {
+    this.treeControl = new NestedTreeControl<UnitTreeNode>(this._getChildren);
+    this.dataSource = new MatTreeNestedDataSource();
+    this.organigramService.getOrganigram().subscribe((organigram) => {
+      this.dataSource.data = organigram;
+    });
+  }
+  public hasChild = (_: number, nodeData: UnitTreeNode) => nodeData.children.length > 0;
+
+  private _getChildren = (node: UnitTreeNode) => node.children;
 
   public ngOnInit() {
-    this.organigramService.getOrganigram().subscribe((organigram) => {
-      this.nodes = organigram;
+    if (this.route.firstChild == null) {
+      return;
+    }
+    this.route.firstChild.paramMap.subscribe((paramMap) => {
+      this.params = OrganigramHelpers.getParamsAsArray(paramMap, [
+        'cityId',
+        'buildingId',
+        'floorId',
+        'roomId',
+      ]);
+      this.updateTreeExtendedState();
     });
+    this.router.events
+      .pipe(
+        untilComponentDestroyed(this),
+        filter((event) => event instanceof NavigationEnd && event.url.includes('rooms')),
+        switchMap(() => (this.route.firstChild ? this.route.firstChild.paramMap : of(null)))
+      )
+      .subscribe((params) => {
+        if (params != null) {
+          this.params = OrganigramHelpers.getParamsAsArray(params, [
+            'cityId',
+            'buildingId',
+            'floorId',
+            'roomId',
+          ]);
+          this.updateTreeExtendedState();
+        }
+      });
+    this.drawerOpenByDefault = this.breakpointObserver.isMatched('(min-width: 1500px)');
+  }
+
+  public updateTreeExtendedState() {
+    this.treeControl.collapseAll();
+    this.params.forEach((x, i) => {
+      const node = UnitTreeNode;
+
+      if (node != null) {
+        return;
+      }
+    });
+  }
+  public navigateToNodePath(nodePath: string[]) {
+    this.router.navigateByUrl(OrganigramHelpers.generateUrlStringFromParamArray(nodePath));
   }
 }

--- a/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.ts
+++ b/Phonebook.Frontend/src/app/modules/organigram/pages/organigram/organigram.component.ts
@@ -48,12 +48,7 @@ export class OrganigramComponent implements OnInit {
       return;
     }
     this.route.firstChild.paramMap.subscribe((paramMap) => {
-      this.params = OrganigramHelpers.getParamsAsArray(paramMap, [
-        'node1Id',
-        'buildingId',
-        'floorId',
-        'roomId',
-      ]);
+      this.params = OrganigramHelpers.getParamsAsArray(paramMap, ['node1Id', 'node2Id', 'node3Id']);
       this.updateTreeExtendedState();
     });
     this.router.events
@@ -66,9 +61,8 @@ export class OrganigramComponent implements OnInit {
         if (params != null) {
           this.params = OrganigramHelpers.getParamsAsArray(params, [
             'node1Id',
-            'buildingId',
-            'floorId',
-            'roomId',
+            'node2Id',
+            'node3Id',
           ]);
           this.updateTreeExtendedState();
         }

--- a/Phonebook.Frontend/src/app/services/api/current-user.service.ts
+++ b/Phonebook.Frontend/src/app/services/api/current-user.service.ts
@@ -42,6 +42,8 @@ export class CurrentUserService {
   }
 
   public getCurrentUserId(): Observable<string> {
+    // Take out before merging!
+    return of('3057');
     return this.getCurrentUserObject().pipe(
       map((str) => {
         // Userstring Layout is "Domain\\user"

--- a/Phonebook.Frontend/src/app/services/api/organigram.service.ts
+++ b/Phonebook.Frontend/src/app/services/api/organigram.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { map, flatMap } from 'rxjs/operators';
 import { Person } from 'src/app/shared/models';
 import { PersonService } from './person.service';
 
@@ -65,6 +65,39 @@ export class OrganigramService {
     } else {
       node.employees.push(person);
     }
+  }
+  public getNodeByPath(pathArray: string[], level: number = 0): Observable<UnitTreeNode | null> {
+    return this.getOrganigram().pipe(
+      flatMap((tree) => {
+        return of(getNodeFromTreeSync(pathArray, tree, level));
+      })
+    );
+  }
+}
+
+export function getNodeFromTreeSync(
+  paramArray: string[],
+  tree: UnitTreeNode[],
+  level: number = 0
+): UnitTreeNode | null {
+  if (paramArray.length === 1) {
+    return (
+      tree.find((node) => {
+        return node.name === paramArray[0];
+      }) || null
+    );
+  } else {
+    const nextNode = tree.find((node) => {
+      return node.name === paramArray[0];
+    });
+    if (nextNode == null || nextNode.children.length === 0) {
+      return null;
+    }
+    return getNodeFromTreeSync(
+      paramArray.slice(1, paramArray.length),
+      nextNode.children,
+      level + 1
+    );
   }
 }
 

--- a/Phonebook.Frontend/src/app/shared/components/user/user-detail/user-detail.component.ts
+++ b/Phonebook.Frontend/src/app/shared/components/user/user-detail/user-detail.component.ts
@@ -86,7 +86,7 @@ export class UserDetailComponent implements OnInit, OnChanges, OnDestroy {
       categories: [...this.person.Business.OrgUnit, ...this.person.Business.ShortOrgUnit],
       nickname: this.person.Id,
     };
-    this.organigramLink = this.organigramLink.concat(this.person.Business.ShortOrgUnit);
+    this.organigramLink = this.organigramLink.concat(this.person.Business.OrgUnit);
   }
 
   public sendMail() {

--- a/Phonebook.Frontend/src/i18n/messages.de.xlf
+++ b/Phonebook.Frontend/src/i18n/messages.de.xlf
@@ -1197,6 +1197,21 @@ Link zu deinem Profil: </target>
           }}</target>
         <note priority="1" from="description">Learners Property</note>
         <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit><trans-unit id="NodeComponentErrorNoNode" datatype="html">
+        <source>Organisation does not exist.</source>
+        <target state="translated">Organisation existiert nicht.</target>
+        <note priority="1" from="description">Error Message if Node does not exist.</note>
+        <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit><trans-unit id="NodeComponentCopiedFirstPart" datatype="html">
+        <source>Link to</source>
+        <target state="translated">Link nach</target>
+        <note priority="1" from="description">First part of the message displayed when copying a link to the node</note>
+        <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit><trans-unit id="NodeComponentCopiedSecondPart" datatype="html">
+        <source>copied to clipboard!</source>
+        <target state="translated">Wurde in die Zwischenablage kopiert!</target>
+        <note priority="1" from="description">Second part of the message displayed when copying a link to the node</note>
+        <note priority="1" from="meaning">NodeComponent</note>
       </trans-unit>
       <trans-unit id="GeneralSuccessMessageCopy" datatype="html">
         <source>Copied to clipboard!</source>

--- a/Phonebook.Frontend/src/i18n/messages.de.xlf
+++ b/Phonebook.Frontend/src/i18n/messages.de.xlf
@@ -1171,6 +1171,32 @@ Link zu deinem Profil: </target>
         <target state="translated">wurde in die Zwischenablage kopiert!</target>
         <note priority="1" from="description">Second part of the message displayed when copying a link to the node</note>
         <note priority="1" from="meaning">OrganigramNodeComponent</note>
+      </trans-unit><trans-unit id="NodeComponentPropertySupervisor" datatype="html">
+        <source>{VAR_PLURAL, plural, =0 {No Supervisor } =1 {Supervisor: } other {Supervisors: }}</source>
+        <target state="translated">{VAR_PLURAL, plural, =0 {Kein Leiter } =1 {Leiter: } other {Leiter: }}</target>
+        <note priority="1" from="description">Supervisor Property</note>
+        <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit><trans-unit id="NodeComponentPropertyAssistant" datatype="html">
+        <source>{VAR_PLURAL, plural, =0 {No Assistant } =1 {Assistant: } other {Assistants:
+        }}</source>
+        <target state="translated">{VAR_PLURAL, plural, =0 {Kein Assistent } =1 {Assistent: } other {Assistenten:
+        }}</target>
+        <note priority="1" from="description">Assistant Property</note>
+        <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit><trans-unit id="NodeComponentPropertyEmployee" datatype="html">
+        <source>{VAR_PLURAL, plural, =0 {No Employees } =1 {Employee: } other {Employees:
+          }}</source>
+        <target state="translated">{VAR_PLURAL, plural, =0 {Keine Mitarbeiter } =1 {Mitarbeiter: } other {Mitarbeiter:
+          }}</target>
+        <note priority="1" from="description">Employee Property</note>
+        <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit><trans-unit id="NodeComponentPropertyLearner" datatype="html">
+        <source>{VAR_PLURAL, plural, =0 {No Learners } =1 {Learner: } other {Learners:
+          }}</source>
+        <target state="translated">{VAR_PLURAL, plural, =0 {Keine Lernenden } =1 {Lernende: } other {Lernende:
+          }}</target>
+        <note priority="1" from="description">Learners Property</note>
+        <note priority="1" from="meaning">NodeComponent</note>
       </trans-unit>
       <trans-unit id="GeneralSuccessMessageCopy" datatype="html">
         <source>Copied to clipboard!</source>
@@ -1227,6 +1253,28 @@ Link zu deinem Profil: </target>
         <source>City does not exist.</source><target state="translated">Diese Stadt existiert nicht.</target>
         <note priority="1" from="description">Error Message if City does not exist.</note>
         <note priority="1" from="meaning">CityComponent</note>
+      </trans-unit><trans-unit id="OrganigramComponentButtonExpandAriaLabel" datatype="html">
+        <source>Button expanding or collapsing the tree view on the left.</source>
+        <target state="translated">Knopf zum ein und ausfahren des Menüs auf der linken Seite.</target>
+        <note priority="1" from="description">Aria Label for expanding the tree
+          view</note>
+        <note priority="1" from="meaning">OrganigramComponent</note>
+      </trans-unit><trans-unit id="OrganigramComponentButtonExpandTooltip" datatype="html">
+        <source>Expand or Collapse the tree view.</source>
+        <target state="translated">Baumansicht ein oder ausfahren.</target>
+        <note priority="1" from="description">Tooltip for expanding the tree
+          view</note>
+        <note priority="1" from="meaning">OrganigramComponent</note>
+      </trans-unit><trans-unit id="OrganigramComponentRootNavigationTitle" datatype="html">
+        <source>Overview</source>
+        <target state="translated">Übersicht</target>
+        <note priority="1" from="description">Root of the Organigram Tree</note>
+        <note priority="1" from="meaning">OrganigramComponent</note>
+      </trans-unit><trans-unit id="OrganigramComponentWhoAmI" datatype="html">
+        <source> Where am I? </source>
+        <target state="translated"> Wo bin ich? </target>
+        <note priority="1" from="description">Button for going to user's organigram</note>
+        <note priority="1" from="meaning">OrganigramComponent</note>
       </trans-unit><trans-unit id="FloorComponentErrorNoFloor" datatype="html">
         <source>Floor does not exist.</source><target state="translated">Dieser Flur existiert nicht.</target>
         <note priority="1" from="description">Error Message if Floor does not exist.</note>

--- a/Phonebook.Frontend/src/i18n/messages.de.xlf
+++ b/Phonebook.Frontend/src/i18n/messages.de.xlf
@@ -1197,6 +1197,11 @@ Link zu deinem Profil: </target>
           }}</target>
         <note priority="1" from="description">Learners Property</note>
         <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit><trans-unit id="NodeComponentPropertySubGroup" datatype="html">
+        <source>Sub-Groups:</source>
+        <target state="translated">Untergruppen:</target>
+        <note priority="1" from="description">SubGroups Property</note>
+        <note priority="1" from="meaning">NodeComponent</note>
       </trans-unit><trans-unit id="NodeComponentErrorNoNode" datatype="html">
         <source>Organisation does not exist.</source>
         <target state="translated">Organisation existiert nicht.</target>
@@ -1285,7 +1290,7 @@ Link zu deinem Profil: </target>
         <target state="translated">Übersicht</target>
         <note priority="1" from="description">Root of the Organigram Tree</note>
         <note priority="1" from="meaning">OrganigramComponent</note>
-      </trans-unit><trans-unit id="OrganigramComponentWhoAmI" datatype="html">
+      </trans-unit><trans-unit id="OrganigramComponentWhereAmI" datatype="html">
         <source> Where am I? </source>
         <target state="translated"> Wo bin ich? </target>
         <note priority="1" from="description">Button for going to user's organigram</note>

--- a/Phonebook.Frontend/src/i18n/messages.en.xlf
+++ b/Phonebook.Frontend/src/i18n/messages.en.xlf
@@ -954,6 +954,32 @@ Please contact the HR Department to fix it.This is the Phonebook Link: </target>
         <target state="final">copied to clipboard!</target>
         <note priority="1" from="description">Second part of the message displayed when copying a link to the node</note>
         <note priority="1" from="meaning">OrganigramNodeComponent</note>
+      </trans-unit><trans-unit id="NodeComponentPropertySupervisor" datatype="html">
+        <source>{VAR_PLURAL, plural, =0 {No Supervisor } =1 {Supervisor: } other {Supervisors: }}</source>
+        <target state="final">{VAR_PLURAL, plural, =0 {No Supervisor } =1 {Supervisor: } other {Supervisors: }}</target>
+        <note priority="1" from="description">Supervisor Property</note>
+        <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit><trans-unit id="NodeComponentPropertyAssistant" datatype="html">
+        <source>{VAR_PLURAL, plural, =0 {No Assistant } =1 {Assistant: } other {Assistants:
+        }}</source>
+        <target state="final">{VAR_PLURAL, plural, =0 {No Assistant } =1 {Assistant: } other {Assistants:
+        }}</target>
+        <note priority="1" from="description">Assistant Property</note>
+        <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit><trans-unit id="NodeComponentPropertyEmployee" datatype="html">
+        <source>{VAR_PLURAL, plural, =0 {No Employees } =1 {Employee: } other {Employees:
+          }}</source>
+        <target state="final">{VAR_PLURAL, plural, =0 {No Employees } =1 {Employee: } other {Employees:
+          }}</target>
+        <note priority="1" from="description">Employee Property</note>
+        <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit><trans-unit id="NodeComponentPropertyLearner" datatype="html">
+        <source>{VAR_PLURAL, plural, =0 {No Learners } =1 {Learner: } other {Learners:
+          }}</source>
+        <target state="final">{VAR_PLURAL, plural, =0 {No Learners } =1 {Learner: } other {Learners:
+          }}</target>
+        <note priority="1" from="description">Learners Property</note>
+        <note priority="1" from="meaning">NodeComponent</note>
       </trans-unit>
       <trans-unit id="GeneralSuccessMessageCopy" datatype="html">
         <source>Copied to clipboard!</source>
@@ -1010,6 +1036,28 @@ Please contact the HR Department to fix it.This is the Phonebook Link: </target>
         <source>City does not exist.</source><target state="final">City does not exist.</target>
         <note priority="1" from="description">Error Message if City does not exist.</note>
         <note priority="1" from="meaning">CityComponent</note>
+      </trans-unit><trans-unit id="OrganigramComponentButtonExpandAriaLabel" datatype="html">
+        <source>Button expanding or collapsing the tree view on the left.</source>
+        <target state="final">Button expanding or collapsing the tree view on the left.</target>
+        <note priority="1" from="description">Aria Label for expanding the tree
+          view</note>
+        <note priority="1" from="meaning">OrganigramComponent</note>
+      </trans-unit><trans-unit id="OrganigramComponentButtonExpandTooltip" datatype="html">
+        <source>Expand or Collapse the tree view.</source>
+        <target state="final">Expand or Collapse the tree view.</target>
+        <note priority="1" from="description">Tooltip for expanding the tree
+          view</note>
+        <note priority="1" from="meaning">OrganigramComponent</note>
+      </trans-unit><trans-unit id="OrganigramComponentRootNavigationTitle" datatype="html">
+        <source>Overview</source>
+        <target state="final">Overview</target>
+        <note priority="1" from="description">Root of the Organigram Tree</note>
+        <note priority="1" from="meaning">OrganigramComponent</note>
+      </trans-unit><trans-unit id="OrganigramComponentWhoAmI" datatype="html">
+        <source> Where am I? </source>
+        <target state="final"> Where am I? </target>
+        <note priority="1" from="description">Button for going to user's organigram</note>
+        <note priority="1" from="meaning">OrganigramComponent</note>
       </trans-unit><trans-unit id="FloorComponentErrorNoFloor" datatype="html">
         <source>Floor does not exist.</source><target state="final">Floor does not exist.</target>
         <note priority="1" from="description">Error Message if Floor does not exist.</note>

--- a/Phonebook.Frontend/src/i18n/messages.en.xlf
+++ b/Phonebook.Frontend/src/i18n/messages.en.xlf
@@ -980,6 +980,11 @@ Please contact the HR Department to fix it.This is the Phonebook Link: </target>
           }}</target>
         <note priority="1" from="description">Learners Property</note>
         <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit><trans-unit id="NodeComponentPropertySubGroup" datatype="html">
+        <source>Sub-Groups:</source>
+        <target state="final">Sub-Groups:</target>
+        <note priority="1" from="description">SubGroups Property</note>
+        <note priority="1" from="meaning">NodeComponent</note>
       </trans-unit><trans-unit id="NodeComponentErrorNoNode" datatype="html">
         <source>Organisation does not exist.</source>
         <target state="final">Organisation does not exist.</target>
@@ -1068,7 +1073,7 @@ Please contact the HR Department to fix it.This is the Phonebook Link: </target>
         <target state="final">Overview</target>
         <note priority="1" from="description">Root of the Organigram Tree</note>
         <note priority="1" from="meaning">OrganigramComponent</note>
-      </trans-unit><trans-unit id="OrganigramComponentWhoAmI" datatype="html">
+      </trans-unit><trans-unit id="OrganigramComponentWhereAmI" datatype="html">
         <source> Where am I? </source>
         <target state="final"> Where am I? </target>
         <note priority="1" from="description">Button for going to user's organigram</note>

--- a/Phonebook.Frontend/src/i18n/messages.en.xlf
+++ b/Phonebook.Frontend/src/i18n/messages.en.xlf
@@ -980,6 +980,21 @@ Please contact the HR Department to fix it.This is the Phonebook Link: </target>
           }}</target>
         <note priority="1" from="description">Learners Property</note>
         <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit><trans-unit id="NodeComponentErrorNoNode" datatype="html">
+        <source>Organisation does not exist.</source>
+        <target state="final">Organisation does not exist.</target>
+        <note priority="1" from="description">Error Message if Node does not exist.</note>
+        <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit><trans-unit id="NodeComponentCopiedFirstPart" datatype="html">
+        <source>Link to</source>
+        <target state="final">Link to</target>
+        <note priority="1" from="description">First part of the message displayed when copying a link to the node</note>
+        <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit><trans-unit id="NodeComponentCopiedSecondPart" datatype="html">
+        <source>copied to clipboard!</source>
+        <target state="final">copied to clipboard!</target>
+        <note priority="1" from="description">Second part of the message displayed when copying a link to the node</note>
+        <note priority="1" from="meaning">NodeComponent</note>
       </trans-unit>
       <trans-unit id="GeneralSuccessMessageCopy" datatype="html">
         <source>Copied to clipboard!</source>

--- a/Phonebook.Frontend/src/i18n/messages.xlf
+++ b/Phonebook.Frontend/src/i18n/messages.xlf
@@ -1133,6 +1133,12 @@ Please contact the HR Department to fix it.This is the Phonebook Link: </target>
         <note priority="1" from="description">Learners Property</note>
         <note priority="1" from="meaning">NodeComponent</note>
       </trans-unit>
+      <trans-unit id="NodeComponentPropertySubGroup" datatype="html">
+        <source>Sub-Groups:</source>
+        <target>Sub-Groups:</target>
+        <note priority="1" from="description">SubGroups Property</note>
+        <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit>
       <trans-unit id="NodeComponentErrorNoNode" datatype="html">
         <source>Organisation does not exist.</source>
         <target>Organisation does not exist.</target>
@@ -1171,7 +1177,7 @@ Please contact the HR Department to fix it.This is the Phonebook Link: </target>
         <note priority="1" from="description">Root of the Organigram Tree</note>
         <note priority="1" from="meaning">OrganigramComponent</note>
       </trans-unit>
-      <trans-unit id="OrganigramComponentWhoAmI" datatype="html">
+      <trans-unit id="OrganigramComponentWhereAmI" datatype="html">
         <source> Where am I? </source>
         <target> Where am I? </target>
         <note priority="1" from="description">Button for going to user&apos;s organigram</note>

--- a/Phonebook.Frontend/src/i18n/messages.xlf
+++ b/Phonebook.Frontend/src/i18n/messages.xlf
@@ -1,816 +1,977 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file source-language="en" datatype="plaintext">
+  <file source-language="en" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="PageInformationNewUrlNoCookies" datatype="html">
         <source>Save the site URL as a favourite now in order to not get any more startup-dialogs. Please notice: You won&apos;t get any information about updates or releases with the set url parameter.</source>
+        <target>Save the site URL as a favourite now in order to not get any more startup-dialogs. Please notice: You won&apos;t get any information about updates or releases with the set url parameter.</target>
         <note priority="1" from="description">Message for just set no cookie url</note>
         <note priority="1" from="meaning">Display advice to new url</note>
       </trans-unit>
       <trans-unit id="PageInformationNewUrlNoCookiesUrl" datatype="html">
         <source>Reset</source>
+        <target>Reset</target>
         <note priority="1" from="description">Message for following no cookie url</note>
         <note priority="1" from="meaning">Restore Url</note>
       </trans-unit>
       <trans-unit id="PageInformationNoDialogs" datatype="html">
         <source>Startup-Dialogs are deactivated. Please notice: You won&apos;t get any information about updates or releases.</source>
+        <target>Startup-Dialogs are deactivated. Please notice: You won&apos;t get any information about updates or releases.</target>
         <note priority="1" from="description">Message to inform user that no dialogs will be shown</note>
         <note priority="1" from="meaning">Warning no dialogs are shown</note>
       </trans-unit>
       <trans-unit id="ChangeProfilePictureDialogComponentTitle" datatype="html">
         <source> Change Profile Picture
 </source>
+        <target> Change Profile Picture
+</target>
         <note priority="1" from="description">Title</note>
         <note priority="1" from="meaning">ChangeProfilePictureDialogComponent</note>
       </trans-unit>
       <trans-unit id="ChangeProfilePictureDialogComponentContent" datatype="html">
         <source><x id="START_PARAGRAPH"/> You&apos;re changing your profile picture? Nice! But please notice: <x id="CLOSE_PARAGRAPH"/><x id="START_UNORDERED_LIST"/><x id="START_LIST_ITEM"/> The picture is used only by the Phonebook Application. <x id="CLOSE_LIST_ITEM"/><x id="START_LIST_ITEM"/> To upload a profile picture is your free choice. <x id="CLOSE_LIST_ITEM"/><x id="START_LIST_ITEM"/> You can change or delete your picture at any time. (Just click the Button right next to the upload Button.) <x id="CLOSE_LIST_ITEM"/><x id="START_LIST_ITEM"/> Your profile picture will deleted if you choose to leave the company. <x id="CLOSE_LIST_ITEM"/><x id="CLOSE_UNORDERED_LIST"/></source>
+        <target><x id="START_PARAGRAPH"/> You&apos;re changing your profile picture? Nice! But please notice: <x id="CLOSE_PARAGRAPH"/><x id="START_UNORDERED_LIST"/><x id="START_LIST_ITEM"/> The picture is used only by the Phonebook Application. <x id="CLOSE_LIST_ITEM"/><x id="START_LIST_ITEM"/> To upload a profile picture is your free choice. <x id="CLOSE_LIST_ITEM"/><x id="START_LIST_ITEM"/> You can change or delete your picture at any time. (Just click the Button right next to the upload Button.) <x id="CLOSE_LIST_ITEM"/><x id="START_LIST_ITEM"/> Your profile picture will deleted if you choose to leave the company. <x id="CLOSE_LIST_ITEM"/><x id="CLOSE_UNORDERED_LIST"/></target>
         <note priority="1" from="description">Content</note>
         <note priority="1" from="meaning">ChangeProfilePictureDialogComponent</note>
       </trans-unit>
       <trans-unit id="GeneralCancelButton" datatype="html">
         <source>Cancel</source>
+        <target>Cancel</target>
       </trans-unit>
       <trans-unit id="ChangeProfilePictureDialogComponentButtonChangePicture" datatype="html">
         <source> Change my Picture! </source>
+        <target> Change my Picture! </target>
         <note priority="1" from="description">Button to consent sending bug
       reports</note>
         <note priority="1" from="meaning">ChangeProfilePictureDialogComponent</note>
       </trans-unit>
       <trans-unit id="ChangeProfilePictureComponentChangeButtonAriaLabel" datatype="html">
         <source>This opens up a dialog to select a profile picture from you file system.</source>
+        <target>This opens up a dialog to select a profile picture from you file system.</target>
         <note priority="1" from="description">Aria Label for the &apos;Change Picture&apos;
         Button</note>
         <note priority="1" from="meaning">ChangeProfilePictureComponent</note>
       </trans-unit>
       <trans-unit id="ChangeProfilePictureComponentChangeButton" datatype="html">
         <source> Change Picture</source>
+        <target> Change Picture</target>
         <note priority="1" from="description">Button for changing the Profile
           Picture</note>
         <note priority="1" from="meaning">ChangeProfilePictureComponent</note>
       </trans-unit>
       <trans-unit id="ChangeProfilePictureComponentDeleteButtonTooltip" datatype="html">
         <source>Delete your Profile Picture</source>
+        <target>Delete your Profile Picture</target>
         <note priority="1" from="description">Tooltip for deleting the Profile
       picture</note>
         <note priority="1" from="meaning">ChangeProfilePictureComponent</note>
       </trans-unit>
       <trans-unit id="ChangeProfilePictureComponentDeleteButtonAriaLabel" datatype="html">
         <source>Button for deleting your Profile Picture.</source>
+        <target>Button for deleting your Profile Picture.</target>
         <note priority="1" from="description">Aria Label for deleting the Profile
       Picture</note>
         <note priority="1" from="meaning">ChangeProfilePictureComponent</note>
       </trans-unit>
       <trans-unit id="ChangeProfilePictureComponentSuccessUpdate" datatype="html">
         <source>Updated your Profile Picture!</source>
+        <target>Updated your Profile Picture!</target>
         <note priority="1" from="description">Success Message if profile picture was updated</note>
         <note priority="1" from="meaning">ChangeProfilePictureComponent</note>
       </trans-unit>
       <trans-unit id="ChangeProfilePictureComponentErrorWrongFileType" datatype="html">
         <source>The File Type is not supported.</source>
+        <target>The File Type is not supported.</target>
         <note priority="1" from="description">Error Message if wrong File Type is supplied</note>
         <note priority="1" from="meaning">ChangeProfilePictureComponent</note>
       </trans-unit>
       <trans-unit id="ChangeProfilePictureComponentErrorWrongFileTypeButton" datatype="html">
         <source>I want to add more support!</source>
+        <target>I want to add more support!</target>
         <note priority="1" from="description">Button on Error Message if wrong File Type is supplied</note>
         <note priority="1" from="meaning">ChangeProfilePictureComponent</note>
       </trans-unit>
       <trans-unit id="GeneralErrorMessage" datatype="html">
         <source>Something went wrong. Please try again.</source>
+        <target>Something went wrong. Please try again.</target>
         <note priority="1" from="description">A general Error message, that can be displayed everywhere</note>
         <note priority="1" from="meaning">GeneralErrorMessage</note>
       </trans-unit>
       <trans-unit id="ChangeProfilePictureComponentErrorFileSize" datatype="html">
         <source>Your file is too big! It should be smaller than</source>
+        <target>Your file is too big! It should be smaller than</target>
         <note priority="1" from="description">Error Message if supplied file size is to big (without size and unit)</note>
         <note priority="1" from="meaning">ChangeProfilePictureComponent</note>
       </trans-unit>
       <trans-unit id="ChangeProfilePictureComponentSuccessDelete" datatype="html">
         <source>Your profile picture was deleted!</source>
+        <target>Your profile picture was deleted!</target>
         <note priority="1" from="description">Success Message if user deleted its profile picture</note>
         <note priority="1" from="meaning">ChangeProfilePictureComponent</note>
       </trans-unit>
       <trans-unit id="TableComponentColumnIdLabel" datatype="html">
         <source>Change sorting for column Id</source>
+        <target>Change sorting for column Id</target>
         <note priority="1" from="description">Label for sorting the column &apos;Id&apos;</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="TableComponentColumnNameLabel" datatype="html">
         <source>Change sorting for column Name</source>
+        <target>Change sorting for column Name</target>
         <note priority="1" from="description">Label for sorting the column &apos;Name&apos;</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="TableComponentColumnPhoneLabel" datatype="html">
         <source>Change sorting for column Phone</source>
+        <target>Change sorting for column Phone</target>
         <note priority="1" from="description">Label for sorting the column &apos;Phone&apos;</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="TableComponentColumnMobileLabel" datatype="html">
         <source>Change sorting for column Mobile</source>
+        <target>Change sorting for column Mobile</target>
         <note priority="1" from="description">Label for sorting the column &apos;Mobile&apos;</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="TableComponentColumnRoleLabel" datatype="html">
         <source>Change sorting for column Role</source>
+        <target>Change sorting for column Role</target>
         <note priority="1" from="description">Label for sorting the column &apos;Role&apos;</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="TableComponentColumnCityLabel" datatype="html">
         <source>Change sorting for column City</source>
+        <target>Change sorting for column City</target>
         <note priority="1" from="description">Label for sorting the column &apos;City&apos;</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="TableComponentColumnOrgUnitLabel" datatype="html">
         <source>Change sorting for column Organization Unit</source>
+        <target>Change sorting for column Organization Unit</target>
         <note priority="1" from="description">Label for sorting the column &apos;Organization
           Unit&apos;</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="TableComponentColumnRoomLabel" datatype="html">
         <source>Change sorting for column Room</source>
+        <target>Change sorting for column Room</target>
         <note priority="1" from="description">Label for sorting the column &apos;Room&apos;</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="TableComponentColumnBuildingLabel" datatype="html">
         <source>Change sorting for column Building</source>
+        <target>Change sorting for column Building</target>
         <note priority="1" from="description">Label for sorting the column &apos;Building&apos;</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="TableComponentColumnCostcenterLabel" datatype="html">
         <source>Change sorting for column Profitcenter</source>
+        <target>Change sorting for column Profitcenter</target>
         <note priority="1" from="description">Label for sorting the column &apos;Profitcenter&apos; once
           Costcenter</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="TableComponentColumnStatusLabel" datatype="html">
         <source>Change sorting for column status</source>
+        <target>Change sorting for column status</target>
         <note priority="1" from="description">Label for sorting the column &apos;Status&apos;</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="TableComponentSearchNoResult" datatype="html">
         <source> Your search returned no results. </source>
+        <target> Your search returned no results. </target>
         <note priority="1" from="description">Sentence displayed if search did not return any
       results</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="TableSettingsDialogTitle" datatype="html">
         <source> Configure Table Columns </source>
+        <target> Configure Table Columns </target>
         <note priority="1" from="description">Title for Table Column Settings</note>
         <note priority="1" from="meaning">TableSettingsDialog</note>
       </trans-unit>
       <trans-unit id="TableSettingsDialogDescription" datatype="html">
         <source> Drag and Drop the Columns in order to arrange them in an order you like. You can hide them as well by dragging them to the right. </source>
+        <target> Drag and Drop the Columns in order to arrange them in an order you like. You can hide them as well by dragging them to the right. </target>
         <note priority="1" from="description">Description for Table Column Settings</note>
         <note priority="1" from="meaning">TableSettingsDialog</note>
       </trans-unit>
       <trans-unit id="TableSettingsDialogNote" datatype="html">
         <source> Note: You can only search for displayed columns. </source>
+        <target> Note: You can only search for displayed columns. </target>
         <note priority="1" from="description">Note for Table Column Settings</note>
         <note priority="1" from="meaning">TableSettingsDialog</note>
       </trans-unit>
       <trans-unit id="TableSettingsDialogSubTitleDisplayedColumns" datatype="html">
         <source> Displayed Columns: </source>
+        <target> Displayed Columns: </target>
         <note priority="1" from="description">Title of displayed table columns</note>
         <note priority="1" from="meaning">TableSettingsDialog</note>
       </trans-unit>
       <trans-unit id="TableSettingsDialogSubTitleNotDisplayedColumns" datatype="html">
         <source> Not displayed Columns: </source>
+        <target> Not displayed Columns: </target>
         <note priority="1" from="description">Title of not displayed table columns</note>
         <note priority="1" from="meaning">TableSettingsDialog</note>
       </trans-unit>
       <trans-unit id="GeneralResetButton" datatype="html">
         <source> Reset </source>
+        <target> Reset </target>
         <note priority="1" from="description">Button for resetting something</note>
         <note priority="1" from="meaning">GeneralResetButton</note>
       </trans-unit>
       <trans-unit id="GeneralCloseButton" datatype="html">
         <source> Close </source>
+        <target> Close </target>
         <note priority="1" from="description">Button for closing something</note>
         <note priority="1" from="meaning">GeneralCloseButton</note>
       </trans-unit>
       <trans-unit id="DashboardComponentTitleRecent" datatype="html">
         <source> Recent People </source>
+        <target> Recent People </target>
         <note priority="1" from="description">Title of the recent people section</note>
         <note priority="1" from="meaning">DashboardComponent</note>
       </trans-unit>
       <trans-unit id="DashboardComponentTitleBookmark" datatype="html">
         <source> Bookmarked People </source>
+        <target> Bookmarked People </target>
         <note priority="1" from="description">Title of the Bookmarked people
             section</note>
         <note priority="1" from="meaning">DashboardComponent</note>
       </trans-unit>
       <trans-unit id="DashboardComponentOrderNone" datatype="html">
         <source> Custom Order</source>
+        <target> Custom Order</target>
         <note priority="1" from="description">The standard (customizable) order of the favorite
                 cards</note>
         <note priority="1" from="meaning">DashboardComponent</note>
       </trans-unit>
       <trans-unit id="DashboardComponentOrderAsc" datatype="html">
         <source> Alphabetical asc</source>
+        <target> Alphabetical asc</target>
         <note priority="1" from="description">The alphabetical asc order of the favorite
                 cards</note>
         <note priority="1" from="meaning">DashboardComponent</note>
       </trans-unit>
       <trans-unit id="DashboardComponentOrderDesc" datatype="html">
         <source> Alphabetical desc</source>
+        <target> Alphabetical desc</target>
         <note priority="1" from="description">The alphabetical desc order of the favorite
                 cards</note>
         <note priority="1" from="meaning">DashboardComponent</note>
       </trans-unit>
       <trans-unit id="dashboardComponentLayoutChangeTooltip" datatype="html">
         <source>Here you can change the layout of your dashboard.</source>
+        <target>Here you can change the layout of your dashboard.</target>
         <note priority="1" from="description">Layout Change Button Tooltip</note>
         <note priority="1" from="meaning">DashboardComponent</note>
       </trans-unit>
       <trans-unit id="DashboardComponentButtonExpandTooltip" datatype="html">
         <source>Expand or Collapse recently viewed people</source>
+        <target>Expand or Collapse recently viewed people</target>
         <note priority="1" from="description">Tooltip for expanding recently viewed
           people</note>
         <note priority="1" from="meaning">DashboardComponent</note>
       </trans-unit>
       <trans-unit id="DashboardComponentButtonExpandArialLabel" datatype="html">
         <source>Button expanding or collapsing the recently viewed people section</source>
+        <target>Button expanding or collapsing the recently viewed people section</target>
         <note priority="1" from="description">Aria Label for expanding recently viewed
           people</note>
         <note priority="1" from="meaning">DashboardComponent</note>
       </trans-unit>
       <trans-unit id="GeneralUndoButton" datatype="html">
         <source> Undo </source>
+        <target> Undo </target>
         <note priority="1" from="description">Button for undoing something</note>
         <note priority="1" from="meaning">GeneralUndoButton</note>
       </trans-unit>
       <trans-unit id="DashboardComponentDescriptionRecent" datatype="html">
         <source> Looks like you haven&apos;t searched for any colleagues yet. Search for somebody to see how it works! The most recent ones will be displayed here. </source>
+        <target> Looks like you haven&apos;t searched for any colleagues yet. Search for somebody to see how it works! The most recent ones will be displayed here. </target>
         <note priority="1" from="description">Message displayed if no people have been visited
               recently</note>
         <note priority="1" from="meaning">DashboardComponent</note>
       </trans-unit>
       <trans-unit id="DashboardComponentDescriptionBookmark" datatype="html">
         <source> You haven&apos;t bookmarked anybody yet, look for the button <x id="START_TAG_BUTTON"/><x id="START_TAG_MAT_ICON"/>bookmark_border<x id="CLOSE_TAG_MAT_ICON"/><x id="CLOSE_TAG_BUTTON"/> on a workmates page. </source>
+        <target> You haven&apos;t bookmarked anybody yet, look for the button <x id="START_TAG_BUTTON"/><x id="START_TAG_MAT_ICON"/>bookmark_border<x id="CLOSE_TAG_MAT_ICON"/><x id="CLOSE_TAG_BUTTON"/> on a workmates page. </target>
         <note priority="1" from="description">Message displayed if no people are
           bookmarked</note>
         <note priority="1" from="meaning">DashboardComponent</note>
       </trans-unit>
       <trans-unit id="NavigationComponentViewModeMediumCards" datatype="html">
         <source>Medium Cards</source>
+        <target>Medium Cards</target>
         <note priority="1" from="description">View Mode - MediumCards</note>
         <note priority="1" from="meaning">NavigationComponent</note>
       </trans-unit>
       <trans-unit id="NavigationComponentViewModeSmallCards" datatype="html">
         <source>Small Cards</source>
+        <target>Small Cards</target>
         <note priority="1" from="description">View Mode - SmallCards</note>
         <note priority="1" from="meaning">NavigationComponent</note>
       </trans-unit>
       <trans-unit id="SettingsComponentTitle" datatype="html">
         <source>Settings</source>
+        <target>Settings</target>
         <note priority="1" from="description">Title of the settings page</note>
         <note priority="1" from="meaning">SettingsComponent</note>
       </trans-unit>
       <trans-unit id="SettingsComponentTitleDescription" datatype="html">
         <source> Change the theme or language of this application. </source>
+        <target> Change the theme or language of this application. </target>
         <note priority="1" from="description">Title description of the settings page</note>
         <note priority="1" from="meaning">SettingsComponent</note>
       </trans-unit>
       <trans-unit id="SettingsComponentSubtitleGeneral" datatype="html">
         <source> General </source>
+        <target> General </target>
         <note priority="1" from="description">Subtitle General of the settings page</note>
         <note priority="1" from="meaning">SettingsComponent</note>
       </trans-unit>
       <trans-unit id="SettingsComponentSubTitleLanguage" datatype="html">
         <source>Language</source>
+        <target>Language</target>
         <note priority="1" from="description">Language SubTitle</note>
         <note priority="1" from="meaning">SettingsComponent</note>
       </trans-unit>
       <trans-unit id="SettingsComponentSubTitleColorTheme" datatype="html">
         <source>Color Theme</source>
+        <target>Color Theme</target>
         <note priority="1" from="description">Color Theme SubTitle</note>
         <note priority="1" from="meaning">SettingsComponent</note>
       </trans-unit>
       <trans-unit id="navigationBarColorChangerTooltip" datatype="html">
         <source>Here you can change the color theme of the app.</source>
+        <target>Here you can change the color theme of the app.</target>
         <note priority="1" from="description">Color Change Button Tooltip</note>
         <note priority="1" from="meaning">navigationBar</note>
       </trans-unit>
       <trans-unit id="SettingsComponentColorThemeBlueLight" datatype="html">
         <source>Blue Light Theme</source>
+        <target>Blue Light Theme</target>
         <note priority="1" from="description">Color Theme Option - Blue Light</note>
         <note priority="1" from="meaning">SettingsComponent</note>
       </trans-unit>
       <trans-unit id="SettingsComponentColorThemeUnicorn" datatype="html">
         <source>Unicorn Theme</source>
+        <target>Unicorn Theme</target>
         <note priority="1" from="description">Color Theme Option -  Unicorn</note>
         <note priority="1" from="meaning">SettingsComponent</note>
       </trans-unit>
       <trans-unit id="SettingsComponentColorThemeBlueDark" datatype="html">
         <source>Blue Dark Theme</source>
+        <target>Blue Dark Theme</target>
         <note priority="1" from="description">Color Theme Option -  Blue Dark</note>
         <note priority="1" from="meaning">SettingsComponent</note>
       </trans-unit>
       <trans-unit id="SettingsComponentColorThemeMagentaLight" datatype="html">
         <source>Magenta Light Theme</source>
+        <target>Magenta Light Theme</target>
         <note priority="1" from="description">Color Theme Option - Magenta Light</note>
         <note priority="1" from="meaning">SettingsComponent</note>
       </trans-unit>
       <trans-unit id="SettingsComponentColorThemeMagentaDark" datatype="html">
         <source>Magenta Dark Theme</source>
+        <target>Magenta Dark Theme</target>
         <note priority="1" from="description">Color Theme Option - Magenta Dark</note>
         <note priority="1" from="meaning">SettingsComponent</note>
       </trans-unit>
       <trans-unit id="UserDetailPageResolverNotFoundFirstPart" datatype="html">
         <source>User with Id</source>
+        <target>User with Id</target>
         <note priority="1" from="description">First part of the message displayed when a user is not found</note>
         <note priority="1" from="meaning">UserDetailPageResolver</note>
       </trans-unit>
       <trans-unit id="UserDetailPageResolverNotFoundSecondPart" datatype="html">
         <source>not found.</source>
+        <target>not found.</target>
         <note priority="1" from="description">Second part of the message displayed when a user is not found</note>
         <note priority="1" from="meaning">UserDetailPageResolver</note>
       </trans-unit>
       <trans-unit id="GeneralLanguageGerman" datatype="html">
         <source>German</source>
+        <target>German</target>
         <note priority="1" from="description">GeneralLanguageGerman</note>
         <note priority="1" from="meaning">GeneralLanguageGerman</note>
       </trans-unit>
       <trans-unit id="GeneralLanguageEnglish" datatype="html">
         <source>English</source>
+        <target>English</target>
         <note priority="1" from="description">GeneralLanguageEnglish</note>
         <note priority="1" from="meaning">GeneralLanguageEnglish</note>
       </trans-unit>
       <trans-unit id="ReleaseInfoServiceSnackBarUpdateTitle" datatype="html">
         <source>We&apos;ve fixed some Bugs and added some new Features for you, with ❤</source>
+        <target>We&apos;ve fixed some Bugs and added some new Features for you, with ❤</target>
         <note priority="1" from="description">Snack Bar display for a feature update</note>
         <note priority="1" from="meaning">ReleaseInfoService</note>
       </trans-unit>
       <trans-unit id="ReleaseInfoServiceSnackBarUpdateButton" datatype="html">
         <source>Fixed what?</source>
+        <target>Fixed what?</target>
         <note priority="1" from="description">Snack Bar display Action Button for a feature update</note>
         <note priority="1" from="meaning">ReleaseInfoService</note>
       </trans-unit>
       <trans-unit id="AddFilterComponentTooltip" datatype="html">
         <source>Add this as a filter</source>
+        <target>Add this as a filter</target>
         <note priority="1" from="description">Tooltip for adding a filter to the search</note>
         <note priority="1" from="meaning">AddFilterComponent</note>
       </trans-unit>
       <trans-unit id="AddFilterComponentAriaLabel" datatype="html">
         <source>Refines the Search by adding this as a Filter.</source>
+        <target>Refines the Search by adding this as a Filter.</target>
         <note priority="1" from="description">Aria Label for adding a filter to the search</note>
         <note priority="1" from="meaning">AddFilterComponent</note>
       </trans-unit>
       <trans-unit id="ColumnTitleRoom" datatype="html">
         <source> Room </source>
+        <target> Room </target>
       </trans-unit>
       <trans-unit id="DataPersonFloor" datatype="html">
         <source>Floor</source>
+        <target>Floor</target>
         <note priority="1" from="description">Label for Person.Floor data</note>
         <note priority="1" from="meaning">Datapoint</note>
       </trans-unit>
       <trans-unit id="UserDetailComponentMessageNoLocation" datatype="html">
         <source> No Location provided. </source>
+        <target> No Location provided. </target>
         <note priority="1" from="description">Message displayed if the location of the user could not be
       determined</note>
         <note priority="1" from="meaning">User-detailComponent</note>
       </trans-unit>
       <trans-unit id="PageInformationComponentSubTitleContribute" datatype="html">
         <source> Call for Contributors! </source>
+        <target> Call for Contributors! </target>
         <note priority="1" from="description">Subtitle Contributes</note>
         <note priority="1" from="meaning">Page-informationComponent</note>
       </trans-unit>
       <trans-unit id="PageInformationComponentSectionContribute" datatype="html">
         <source><x id="START_TAG_SPAN"/> The Phonebook is an Open Source Project and lives from his active contributors. There are many different topics where you can work on. You can help with solving an <x id="START_LINK"/>Issue<x id="CLOSE_LINK"/>, work out an User-Guide or document new <x id="START_LINK_1"/>Bugs<x id="CLOSE_LINK"/>. <x id="CLOSE_TAG_SPAN"/><x id="START_TAG_SPAN"/> You can get in touch with us <x id="START_LINK_2"/>in our official Repository<x id="CLOSE_LINK"/> or you take a look at our <x id="START_LINK_3"/>Documentation<x id="CLOSE_LINK"/>. <x id="START_TAG_DIV"/><x id="START_BOLD_TEXT"/>To be a part of this community it is not required to have programming skills.<x id="CLOSE_BOLD_TEXT"/><x id="CLOSE_TAG_DIV"/><x id="CLOSE_TAG_SPAN"/><x id="START_TAG_DIV_2"/><x id="START_HEADING_LEVEL2"/>Thanks to our Contributors!<x id="CLOSE_HEADING_LEVEL2"/><x id="START_TAG_DIV_1"/><x id="CLOSE_TAG_DIV"/><x id="CLOSE_TAG_DIV"/></source>
+        <target><x id="START_TAG_SPAN"/> The Phonebook is an Open Source Project and lives from his active contributors. There are many different topics where you can work on. You can help with solving an <x id="START_LINK"/>Issue<x id="CLOSE_LINK"/>, work out an User-Guide or document new <x id="START_LINK_1"/>Bugs<x id="CLOSE_LINK"/>. <x id="CLOSE_TAG_SPAN"/><x id="START_TAG_SPAN"/> You can get in touch with us <x id="START_LINK_2"/>in our official Repository<x id="CLOSE_LINK"/> or you take a look at our <x id="START_LINK_3"/>Documentation<x id="CLOSE_LINK"/>. <x id="START_TAG_DIV"/><x id="START_BOLD_TEXT"/>To be a part of this community it is not required to have programming skills.<x id="CLOSE_BOLD_TEXT"/><x id="CLOSE_TAG_DIV"/><x id="CLOSE_TAG_SPAN"/><x id="START_TAG_DIV_2"/><x id="START_HEADING_LEVEL2"/>Thanks to our Contributors!<x id="CLOSE_HEADING_LEVEL2"/><x id="START_TAG_DIV_1"/><x id="CLOSE_TAG_DIV"/><x id="CLOSE_TAG_DIV"/></target>
         <note priority="1" from="description">Text for Contribute</note>
         <note priority="1" from="meaning">Page-informationComponent</note>
       </trans-unit>
       <trans-unit id="ContributorsErrorMessage" datatype="html">
         <source>Contributors could not be loaded.</source>
+        <target>Contributors could not be loaded.</target>
         <note priority="1" from="description">Contributors error Message</note>
         <note priority="1" from="meaning">ContributorsErrorMessage</note>
       </trans-unit>
       <trans-unit id="navigationDashboard" datatype="html">
         <source> Dashboard </source>
+        <target> Dashboard </target>
         <note priority="1" from="description">Link to Dashboard</note>
         <note priority="1" from="meaning">NavigationBar</note>
       </trans-unit>
       <trans-unit id="navigationOrganigram" datatype="html">
         <source> Organigram </source>
+        <target> Organigram </target>
         <note priority="1" from="description">Link to Organigram</note>
         <note priority="1" from="meaning">NavigationBar</note>
       </trans-unit>
       <trans-unit id="navigationRooms" datatype="html">
         <source> Rooms </source>
+        <target> Rooms </target>
         <note priority="1" from="description">Link to Rooms</note>
         <note priority="1" from="meaning">NavigationBar</note>
       </trans-unit>
       <trans-unit id="NavigationComponentMyProfile" datatype="html">
         <source>My profile</source>
+        <target>My profile</target>
         <note priority="1" from="description">Link to the users profile</note>
         <note priority="1" from="meaning">NavigationComponent</note>
       </trans-unit>
       <trans-unit id="navigationBarInfoTooltip" datatype="html">
         <source>Got Feedback? Than that`s the right place to click.</source>
+        <target>Got Feedback? Than that`s the right place to click.</target>
         <note priority="1" from="description">Info Button Tooltip</note>
         <note priority="1" from="meaning">navigationBar</note>
       </trans-unit>
       <trans-unit id="NavigationComponentInformation" datatype="html">
         <source>Information</source>
+        <target>Information</target>
         <note priority="1" from="description">Link to Information page</note>
         <note priority="1" from="meaning">NavigationComponent</note>
       </trans-unit>
       <trans-unit id="NavigationComponentReleaseNotes" datatype="html">
         <source>Release Notes</source>
+        <target>Release Notes</target>
         <note priority="1" from="description">Release Notes Menu Item</note>
         <note priority="1" from="meaning">NavigationComponent</note>
       </trans-unit>
       <trans-unit id="navigationBarBugTooltip" datatype="html">
         <source>Found a Bug? Than that`s the right place to click.</source>
+        <target>Found a Bug? Than that`s the right place to click.</target>
         <note priority="1" from="description">Bug Button Tooltip</note>
         <note priority="1" from="meaning">navigationBar</note>
       </trans-unit>
       <trans-unit id="NavigationComponentFeedback" datatype="html">
         <source>Submit Feedback</source>
+        <target>Submit Feedback</target>
         <note priority="1" from="description">Link to Bug page</note>
         <note priority="1" from="meaning">NavigationComponent</note>
       </trans-unit>
       <trans-unit id="navigationBarApplicationName" datatype="html">
         <source>Phonebook</source>
+        <target>Phonebook</target>
         <note priority="1" from="description">Application Name</note>
         <note priority="1" from="meaning">NavigationBar</note>
       </trans-unit>
       <trans-unit id="MissingUserImageTooltip" datatype="html">
         <source>If you upload a picture it will be easier for your colleagues to find and contact you!</source>
+        <target>If you upload a picture it will be easier for your colleagues to find and contact you!</target>
         <note priority="1" from="description">Tooltip for MissingUserImage</note>
         <note priority="1" from="meaning">NavigationComponent</note>
       </trans-unit>
       <trans-unit id="MissingUserImageAriaLabel" datatype="html">
         <source>Button which greets and asks for picture uploading.</source>
+        <target>Button which greets and asks for picture uploading.</target>
         <note priority="1" from="description">Aria label for MissingUserImage</note>
         <note priority="1" from="meaning">NavigationComponent</note>
       </trans-unit>
       <trans-unit id="MissingUserImageGreeting" datatype="html">
         <source>Hey</source>
+        <target>Hey</target>
         <note priority="1" from="description">Greeting</note>
         <note priority="1" from="meaning">NavigationComponent</note>
       </trans-unit>
       <trans-unit id="MissingUserImageMessage" datatype="html">
         <source>you haven&apos;t uploaded a picture yet. Want to upload one?</source>
+        <target>you haven&apos;t uploaded a picture yet. Want to upload one?</target>
         <note priority="1" from="description">Message</note>
         <note priority="1" from="meaning">NavigationComponent</note>
       </trans-unit>
       <trans-unit id="TableComponentResultCount" datatype="html">
         <source> <x id="INTERPOLATION"/> Results </source>
+        <target> <x id="INTERPOLATION"/> Results </target>
         <note priority="1" from="description">Result Count</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="navigationBarGreetingsMessageFirstApril" datatype="html">
         <source>Happy April Fools&apos; Day</source>
+        <target>Happy April Fools&apos; Day</target>
         <note priority="1" from="description">Greetings Message on first April</note>
         <note priority="1" from="meaning">NavigationBar</note>
       </trans-unit>
       <trans-unit id="navigationBarGreetingsMessage" datatype="html">
         <source>Have a nice day</source>
+        <target>Have a nice day</target>
         <note priority="1" from="description">Greetings Message</note>
         <note priority="1" from="meaning">NavigationBar</note>
       </trans-unit>
       <trans-unit id="OnlineBarComponentOnline" datatype="html">
         <source>The green bar indicates that you are online.</source>
+        <target>The green bar indicates that you are online.</target>
         <note priority="1" from="description">Tooltip for bar indicating the user is online</note>
         <note priority="1" from="meaning">Online-barComponent</note>
       </trans-unit>
       <trans-unit id="OnlineBarComponentOffline" datatype="html">
         <source>The red bar indicates that you are offline.</source>
+        <target>The red bar indicates that you are offline.</target>
         <note priority="1" from="description">Tooltip for bar indicating the user is offline</note>
         <note priority="1" from="meaning">Online-barComponent</note>
       </trans-unit>
       <trans-unit id="RoomPlanComponentNoPlan" datatype="html">
         <source><x id="START_PARAGRAPH"/> Unfortunately there is no plan for this floor. <x id="CLOSE_PARAGRAPH"/><x id="START_PARAGRAPH"/> Do you know who can make one or want to help us fix this? <x id="CLOSE_PARAGRAPH"/><x id="START_LINK"/><x id="START_TAG_MAT_ICON"/>code<x id="CLOSE_TAG_MAT_ICON"/> Contribute <x id="CLOSE_LINK"/></source>
+        <target><x id="START_PARAGRAPH"/> Unfortunately there is no plan for this floor. <x id="CLOSE_PARAGRAPH"/><x id="START_PARAGRAPH"/> Do you know who can make one or want to help us fix this? <x id="CLOSE_PARAGRAPH"/><x id="START_LINK"/><x id="START_TAG_MAT_ICON"/>code<x id="CLOSE_TAG_MAT_ICON"/> Contribute <x id="CLOSE_LINK"/></target>
         <note priority="1" from="description">Message displayed if there is no room plan</note>
         <note priority="1" from="meaning">RoomPlanComponent</note>
       </trans-unit>
       <trans-unit id="SearchComponentPlaceholder" datatype="html">
         <source>Search for names, shorthands, phone numbers and more...</source>
+        <target>Search for names, shorthands, phone numbers and more...</target>
         <note priority="1" from="description">Placholder for search</note>
         <note priority="1" from="meaning">SearchComponent</note>
       </trans-unit>
       <trans-unit id="UserDetailComponentTooltipDataChange" datatype="html">
         <source>Found Incorrect Data? Report them!</source>
+        <target>Found Incorrect Data? Report them!</target>
         <note priority="1" from="description">Tooltip Incorrect Data</note>
         <note priority="1" from="meaning">User-detailComponent</note>
       </trans-unit>
       <trans-unit id="UserDetailComponentTooltipBookmark" datatype="html">
         <source>Bookmark this person</source>
+        <target>Bookmark this person</target>
         <note priority="1" from="description">Tooltip for saving a person as
               favourite</note>
         <note priority="1" from="meaning">User-detailComponent</note>
       </trans-unit>
       <trans-unit id="UserDetailComponentTooltipShare" datatype="html">
         <source>Share</source>
+        <target>Share</target>
         <note priority="1" from="description">Tooltip for opening the share menu</note>
         <note priority="1" from="meaning">User-detailComponent</note>
       </trans-unit>
       <trans-unit id="UserDetailComponentShareDownloadContact" datatype="html">
         <source>Download Contact</source>
+        <target>Download Contact</target>
         <note priority="1" from="description">Share Menu: Donwload Contact
                 Option</note>
         <note priority="1" from="meaning">User-detailComponent</note>
       </trans-unit>
       <trans-unit id="UserDetailComponentShareLink" datatype="html">
         <source>Link</source>
+        <target>Link</target>
         <note priority="1" from="description">Share Menu: Link Option</note>
         <note priority="1" from="meaning">User-detailComponent</note>
       </trans-unit>
       <trans-unit id="UserDetailComponentShareMail" datatype="html">
         <source>Share by mail</source>
+        <target>Share by mail</target>
         <note priority="1" from="description">Share Menu: Mail Option</note>
         <note priority="1" from="meaning">User-detailComponent</note>
       </trans-unit>
       <trans-unit id="UserDetailComponentSubTitleContactDetails" datatype="html">
         <source> Contact Details </source>
+        <target> Contact Details </target>
         <note priority="1" from="description">Subtitle for Contact
               Details</note>
         <note priority="1" from="meaning">User-detailComponent</note>
       </trans-unit>
       <trans-unit id="UserDetailComponentShareRocketChat" datatype="html">
         <source>Rocket Chat</source>
+        <target>Rocket Chat</target>
         <note priority="1" from="description">Share Menu: Rocket Chat
                 Option</note>
         <note priority="1" from="meaning">User-detailComponent</note>
       </trans-unit>
       <trans-unit id="ColumnTitleEmail" datatype="html">
         <source>Email</source>
+        <target>Email</target>
       </trans-unit>
       <trans-unit id="ColumnTitlePhone" datatype="html">
         <source>Phone</source>
+        <target>Phone</target>
       </trans-unit>
       <trans-unit id="ColumnTitleMobile" datatype="html">
         <source>Mobile</source>
+        <target>Mobile</target>
       </trans-unit>
       <trans-unit id="DataPersonFax" datatype="html">
         <source> Fax </source>
+        <target> Fax </target>
         <note priority="1" from="description">Label for Person.Fax data</note>
         <note priority="1" from="meaning">Datapoint</note>
       </trans-unit>
       <trans-unit id="UserDetailComponentSubTitleFurtherInformation" datatype="html">
         <source> Further Information </source>
+        <target> Further Information </target>
         <note priority="1" from="description">Subtitle for Further
               Information</note>
         <note priority="1" from="meaning">User-detailComponent</note>
       </trans-unit>
       <trans-unit id="DataPersonDirectSupervisor" datatype="html">
         <source> Direct Supervisor </source>
+        <target> Direct Supervisor </target>
         <note priority="1" from="description">Label for Person.Supervisor (direct supervisor)
                 </note>
         <note priority="1" from="meaning">Datapoint</note>
       </trans-unit>
       <trans-unit id="DataPersonTeamAssistant" datatype="html">
         <source> Team Assistants </source>
+        <target> Team Assistants </target>
         <note priority="1" from="description">Label for Person.TeamAssistant </note>
         <note priority="1" from="meaning">Datapoint</note>
       </trans-unit>
       <trans-unit id="ColumnTitleCostcenter" datatype="html">
         <source>Profitcenter</source>
+        <target>Profitcenter</target>
       </trans-unit>
       <trans-unit id="DataPersonStatus" datatype="html">
         <source> Status </source>
+        <target> Status </target>
         <note priority="1" from="description">Label for Person.Status data</note>
         <note priority="1" from="meaning">Datapoint</note>
       </trans-unit>
       <trans-unit id="ColumnTitleOrgUnit" datatype="html">
         <source> Organization Unit </source>
+        <target> Organization Unit </target>
       </trans-unit>
       <trans-unit id="UserDetailComponentButtonShowInOrganigram" datatype="html">
         <source>Show in Organigram</source>
+        <target>Show in Organigram</target>
         <note priority="1" from="description">Button to show the persons position in the
                     organigram</note>
         <note priority="1" from="meaning">User-detailComponent</note>
       </trans-unit>
       <trans-unit id="UserDetailComponentLabelLocation" datatype="html">
         <source> Location </source>
+        <target> Location </target>
         <note priority="1" from="description">Combined location of the person (city, building, floor,
                   room)</note>
         <note priority="1" from="meaning">User-detailComponent</note>
       </trans-unit>
       <trans-unit id="UserDetailComponentButtonShowRoom" datatype="html">
         <source> Show Room </source>
+        <target> Show Room </target>
         <note priority="1" from="description">Button to show the persons
                     room</note>
         <note priority="1" from="meaning">User-detailComponent</note>
       </trans-unit>
       <trans-unit id="UserDetailComponentTabHeadlineRoomplan" datatype="html">
         <source>Roomplan</source>
+        <target>Roomplan</target>
         <note priority="1" from="description">Tab Headline for Roomplan</note>
         <note priority="1" from="meaning">UserDetailComponent</note>
       </trans-unit>
       <trans-unit id="UserDetailComponentTabHeadlineSkills" datatype="html">
         <source>Skills</source>
+        <target>Skills</target>
         <note priority="1" from="description">Tab Headline for Skills</note>
         <note priority="1" from="meaning">UserDetailComponent</note>
       </trans-unit>
       <trans-unit id="UserDetailComponenMessageContributeSkills" datatype="html">
         <source> This is where a coworkers skills would be shown. But this is still work in Progress, you can make it happen faster! <x id="START_LINK"/><x id="START_TAG_MAT_ICON"/>code<x id="CLOSE_TAG_MAT_ICON"/> Contribute <x id="CLOSE_LINK"/><x id="START_TAG_SPAN"/><x id="CLOSE_TAG_SPAN"/></source>
+        <target> This is where a coworkers skills would be shown. But this is still work in Progress, you can make it happen faster! <x id="START_LINK"/><x id="START_TAG_MAT_ICON"/>code<x id="CLOSE_TAG_MAT_ICON"/> Contribute <x id="CLOSE_LINK"/><x id="START_TAG_SPAN"/><x id="CLOSE_TAG_SPAN"/></target>
         <note priority="1" from="description">Text for the upcoming skill tag
                 feature</note>
         <note priority="1" from="meaning">User-detailComponent</note>
       </trans-unit>
       <trans-unit id="ColumnTitlePicture" datatype="html">
         <source>Picture</source>
+        <target>Picture</target>
         <note priority="1" from="description">Title of Table Column &quot;Picture&quot;</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="ColumnTitleId" datatype="html">
         <source>Id</source>
+        <target>Id</target>
         <note priority="1" from="description">Title of Table Column &quot;Id&quot;</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="ColumnTitleFullName" datatype="html">
         <source>Name</source>
+        <target>Name</target>
         <note priority="1" from="description">Title of Table Column &quot;Name&quot;</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="ColumnEmailName" datatype="html">
         <source>Email</source>
+        <target>Email</target>
         <note priority="1" from="description">Title of Table Column &quot;Email&quot;</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="ColumnTitleRole" datatype="html">
         <source>Role</source>
+        <target>Role</target>
         <note priority="1" from="description">Title of Table Column &quot;Role&quot;</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="ColumnTitleCity" datatype="html">
         <source>City</source>
+        <target>City</target>
         <note priority="1" from="description">Title of Table Column &quot;City&quot;</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="ColumnTitleBuilding" datatype="html">
         <source>Building</source>
+        <target>Building</target>
         <note priority="1" from="description">Title of Table Column &quot;Building&quot;</note>
         <note priority="1" from="meaning">TableComponent</note>
       </trans-unit>
       <trans-unit id="BugReportConsentComponentTitle" datatype="html">
         <source> We need your help! </source>
+        <target> We need your help! </target>
         <note priority="1" from="description">Title of Bug Report Consent Dialog</note>
         <note priority="1" from="meaning">Bug-report-consentComponent</note>
       </trans-unit>
       <trans-unit id="BugReportConsentComponentSubTitle" datatype="html">
         <source> Sending automatic Bug reports </source>
+        <target> Sending automatic Bug reports </target>
         <note priority="1" from="description">Sub title of bug report consent
         dialog</note>
         <note priority="1" from="meaning">Bug-report-consentComponent</note>
       </trans-unit>
       <trans-unit id="BugReportConsentComponentText" datatype="html">
         <source><x id="START_PARAGRAPH"/> If an error occurs while the application is running, an anonymous error report is automatically generated. In exceptional cases - since this is a preview - the following personal data can still be found in one of the reports: <x id="CLOSE_PARAGRAPH"/><x id="START_TAG_MAT_LIST"/><x id="START_TAG_MAT_LIST_ITEM"/> Username (short and full name) <x id="CLOSE_TAG_MAT_LIST_ITEM"/><x id="START_TAG_MAT_LIST_ITEM"/> Bookmarks and Last seen people <x id="CLOSE_TAG_MAT_LIST_ITEM"/><x id="START_TAG_MAT_LIST_ITEM"/> The Last 20 Actions performed in the app <x id="CLOSE_TAG_MAT_LIST_ITEM"/><x id="CLOSE_TAG_MAT_LIST"/><x id="START_PARAGRAPH"/> The data from the error report is used exclusively for the purpose of analysis and correction of the error by our core development team. The data will not be passed on to third parties. <x id="CLOSE_PARAGRAPH"/><x id="START_PARAGRAPH"/><x id="START_TAG_STRONG"/>TL;DR With your permission, you agree that bug reports that may contain your personal data can be sent to our core development team and be used for error analysis and resolution. <x id="CLOSE_TAG_STRONG"/><x id="CLOSE_PARAGRAPH"/></source>
+        <target><x id="START_PARAGRAPH"/> If an error occurs while the application is running, an anonymous error report is automatically generated. In exceptional cases - since this is a preview - the following personal data can still be found in one of the reports: <x id="CLOSE_PARAGRAPH"/><x id="START_TAG_MAT_LIST"/><x id="START_TAG_MAT_LIST_ITEM"/> Username (short and full name) <x id="CLOSE_TAG_MAT_LIST_ITEM"/><x id="START_TAG_MAT_LIST_ITEM"/> Bookmarks and Last seen people <x id="CLOSE_TAG_MAT_LIST_ITEM"/><x id="START_TAG_MAT_LIST_ITEM"/> The Last 20 Actions performed in the app <x id="CLOSE_TAG_MAT_LIST_ITEM"/><x id="CLOSE_TAG_MAT_LIST"/><x id="START_PARAGRAPH"/> The data from the error report is used exclusively for the purpose of analysis and correction of the error by our core development team. The data will not be passed on to third parties. <x id="CLOSE_PARAGRAPH"/><x id="START_PARAGRAPH"/><x id="START_TAG_STRONG"/>TL;DR With your permission, you agree that bug reports that may contain your personal data can be sent to our core development team and be used for error analysis and resolution. <x id="CLOSE_TAG_STRONG"/><x id="CLOSE_PARAGRAPH"/></target>
         <note priority="1" from="description">Text of Bug Report consent dialog</note>
         <note priority="1" from="meaning">Bug-report-consentComponent</note>
       </trans-unit>
       <trans-unit id="BugReportConsentComponentButtonDecline" datatype="html">
         <source> Do not send Bug Reports </source>
+        <target> Do not send Bug Reports </target>
         <note priority="1" from="description">Button to decline sending bug
           reports</note>
         <note priority="1" from="meaning">Bug-report-consentComponent</note>
       </trans-unit>
       <trans-unit id="BugReportConsentComponentButtonConsent" datatype="html">
         <source> Consent </source>
+        <target> Consent </target>
         <note priority="1" from="description">Button to consent sending bug
           reports</note>
         <note priority="1" from="meaning">Bug-report-consentComponent</note>
       </trans-unit>
       <trans-unit id="WelcomeHeadline" datatype="html">
         <source> Welcome to the new Phonebook! </source>
+        <target> Welcome to the new Phonebook! </target>
         <note priority="1" from="description">Welcome Headline</note>
         <note priority="1" from="meaning">Display-notificationDialog</note>
       </trans-unit>
       <trans-unit id="WelcomeIntroduction" datatype="html">
         <source>The new Phonebook not only offers you a new design, but also numerous features that make it better than its predecessor. </source>
+        <target>The new Phonebook not only offers you a new design, but also numerous features that make it better than its predecessor. </target>
         <note priority="1" from="description">Welcome Introduction</note>
         <note priority="1" from="meaning">Display-notificationDialog</note>
       </trans-unit>
       <trans-unit id="WelcomeFeatureProfilePictureHeadline" datatype="html">
         <source> You can set a profile picture by yourself </source>
+        <target> You can set a profile picture by yourself </target>
         <note priority="1" from="description">Profile Image Feature Headline</note>
         <note priority="1" from="meaning">Display-notificationDialog</note>
       </trans-unit>
       <trans-unit id="WelcomeFeatureProfilePictureDescription" datatype="html">
         <source> Simply click on the <x id="START_TAG_BUTTON"/><x id="START_TAG_MAT_ICON"/>person<x id="CLOSE_TAG_MAT_ICON"/><x id="CLOSE_TAG_BUTTON"/> icon in the upper right corner and then on &quot;My Profile&quot;. </source>
+        <target> Simply click on the <x id="START_TAG_BUTTON"/><x id="START_TAG_MAT_ICON"/>person<x id="CLOSE_TAG_MAT_ICON"/><x id="CLOSE_TAG_BUTTON"/> icon in the upper right corner and then on &quot;My Profile&quot;. </target>
         <note priority="1" from="description">Profile Image Feature Description</note>
         <note priority="1" from="meaning">Display-notificationDialog</note>
       </trans-unit>
       <trans-unit id="WelcomeFeatureBookmarkHeadline" datatype="html">
         <source> Colleagues can be saved as a favorite </source>
+        <target> Colleagues can be saved as a favorite </target>
         <note priority="1" from="description">Bookmark Feature Headline</note>
         <note priority="1" from="meaning">Display-notificationDialog</note>
       </trans-unit>
       <trans-unit id="WelcomeFeatureBookmarkDescription" datatype="html">
         <source> Just click on the <x id="START_TAG_BUTTON"/><x id="START_TAG_MAT_ICON"/>bookmark_border<x id="CLOSE_TAG_MAT_ICON"/><x id="CLOSE_TAG_BUTTON"/> icon at one of your colleagues. </source>
+        <target> Just click on the <x id="START_TAG_BUTTON"/><x id="START_TAG_MAT_ICON"/>bookmark_border<x id="CLOSE_TAG_MAT_ICON"/><x id="CLOSE_TAG_BUTTON"/> icon at one of your colleagues. </target>
         <note priority="1" from="description">Bookmark Feature Description</note>
         <note priority="1" from="meaning">Display-notificationDialog</note>
       </trans-unit>
       <trans-unit id="WelcomeFeatureTableSettingsHeadline" datatype="html">
         <source> Table columns can be sorted and customized </source>
+        <target> Table columns can be sorted and customized </target>
         <note priority="1" from="description">Table Settings Headlin</note>
         <note priority="1" from="meaning">Display-notificationDialog</note>
       </trans-unit>
       <trans-unit id="WelcomeFeatureTableSettingsDescription" datatype="html">
         <source> The settings <x id="START_TAG_BUTTON"/><x id="START_TAG_MAT_ICON"/>settings<x id="CLOSE_TAG_MAT_ICON"/><x id="CLOSE_TAG_BUTTON"/> can be found at the search page in the upper right corner. </source>
+        <target> The settings <x id="START_TAG_BUTTON"/><x id="START_TAG_MAT_ICON"/>settings<x id="CLOSE_TAG_MAT_ICON"/><x id="CLOSE_TAG_BUTTON"/> can be found at the search page in the upper right corner. </target>
         <note priority="1" from="description">Table Settings Description</note>
         <note priority="1" from="meaning">Display-notificationDialog</note>
       </trans-unit>
       <trans-unit id="WelcomeFeatureShareHeadline" datatype="html">
         <source> People can be shared via links </source>
+        <target> People can be shared via links </target>
         <note priority="1" from="description">Share Headline</note>
         <note priority="1" from="meaning">Display-notificationDialog</note>
       </trans-unit>
       <trans-unit id="WelcomeFeatureShareDescription" datatype="html">
         <source> The different ways to share a profile can be found by clicking on the <x id="START_TAG_BUTTON"/><x id="START_TAG_MAT_ICON"/>share<x id="CLOSE_TAG_MAT_ICON"/><x id="CLOSE_TAG_BUTTON"/> icon. </source>
+        <target> The different ways to share a profile can be found by clicking on the <x id="START_TAG_BUTTON"/><x id="START_TAG_MAT_ICON"/>share<x id="CLOSE_TAG_MAT_ICON"/><x id="CLOSE_TAG_BUTTON"/> icon. </target>
         <note priority="1" from="description">Share description</note>
         <note priority="1" from="meaning">Display-notificationDialog</note>
       </trans-unit>
       <trans-unit id="WelcomeFeatureLanguageHeadline" datatype="html">
         <source> The Phonebook is available in German and English </source>
+        <target> The Phonebook is available in German and English </target>
         <note priority="1" from="description">Language Headline</note>
         <note priority="1" from="meaning">Display-notificationDialog</note>
       </trans-unit>
       <trans-unit id="WelcomeFeatureLanguageDescription" datatype="html">
         <source> Simply click on the <x id="START_TAG_BUTTON"/><x id="START_TAG_MAT_ICON"/>person<x id="CLOSE_TAG_MAT_ICON"/><x id="CLOSE_TAG_BUTTON"/> icon in the top right corner and go to the settings. </source>
+        <target> Simply click on the <x id="START_TAG_BUTTON"/><x id="START_TAG_MAT_ICON"/>person<x id="CLOSE_TAG_MAT_ICON"/><x id="CLOSE_TAG_BUTTON"/> icon in the top right corner and go to the settings. </target>
         <note priority="1" from="description">Language description</note>
         <note priority="1" from="meaning">Display-notificationDialog</note>
       </trans-unit>
       <trans-unit id="WelcomeFeatureRoomplanHeadline" datatype="html">
         <source> You can view a roomplan for each employee </source>
+        <target> You can view a roomplan for each employee </target>
         <note priority="1" from="description">Room Plan Headline</note>
         <note priority="1" from="meaning">Display-notificationDialog</note>
       </trans-unit>
       <trans-unit id="WelcomeFeatureRoomplanDescription" datatype="html">
         <source> Just go to the profile of a colleague and scroll down. </source>
+        <target> Just go to the profile of a colleague and scroll down. </target>
         <note priority="1" from="description">Room Plan description</note>
         <note priority="1" from="meaning">Display-notificationDialog</note>
       </trans-unit>
       <trans-unit id="WelcomeCookieNotice" datatype="html">
         <source> This site uses cookies to ensure the basic functionality of the app. </source>
+        <target> This site uses cookies to ensure the basic functionality of the app. </target>
         <note priority="1" from="description">Cookie notice</note>
         <note priority="1" from="meaning">Display-notificationDialog</note>
       </trans-unit>
       <trans-unit id="PageInformationNewUrlNoCookiesText" datatype="html">
         <source> You deactivated cookies and keep getting those dialogs? </source>
+        <target> You deactivated cookies and keep getting those dialogs? </target>
         <note priority="1" from="description">Annoyed by cookies notice</note>
         <note priority="1" from="meaning">Display-notificationDialog</note>
       </trans-unit>
       <trans-unit id="PageInformationNewUrlNoCookiesButton" datatype="html">
         <source> Deactivate startup-dialogs! </source>
+        <target> Deactivate startup-dialogs! </target>
         <note priority="1" from="description">Deactivate Startup Dialogs</note>
         <note priority="1" from="meaning">Display-notificationDialog</note>
       </trans-unit>
       <trans-unit id="IeWarningComponentTitle" datatype="html">
         <source> This Website may not function properly in Internet Explorer
 </source>
+        <target> This Website may not function properly in Internet Explorer
+</target>
         <note priority="1" from="description">Title</note>
         <note priority="1" from="meaning">IeWarningComponent</note>
       </trans-unit>
       <trans-unit id="IeWarningComponentContent" datatype="html">
         <source><x id="START_PARAGRAPH"/> The support for older versions of Internet Explorer <x id="START_LINK"/>ended in 2016<x id="CLOSE_LINK"/>. It is not actively developed anymore and as such lags modern features. <x id="CLOSE_PARAGRAPH"/><x id="START_PARAGRAPH"/> Making a feature work in Internet Explorer takes up as much time as building the feature itself for all other browser. As we only have limited time we strive to develop features of the future instead of supporting the past. <x id="CLOSE_PARAGRAPH"/><x id="START_PARAGRAPH"/> Please change to a more modern browser: <x id="START_LINK_1"/>Chrome<x id="CLOSE_LINK"/>, <x id="START_LINK_2"/>Firefox<x id="CLOSE_LINK"/>, <x id="START_LINK_3"/>Edge<x id="CLOSE_LINK"/>, <x id="START_LINK_4"/>Safari<x id="CLOSE_LINK"/>. <x id="CLOSE_PARAGRAPH"/></source>
+        <target><x id="START_PARAGRAPH"/> The support for older versions of Internet Explorer <x id="START_LINK"/>ended in 2016<x id="CLOSE_LINK"/>. It is not actively developed anymore and as such lags modern features. <x id="CLOSE_PARAGRAPH"/><x id="START_PARAGRAPH"/> Making a feature work in Internet Explorer takes up as much time as building the feature itself for all other browser. As we only have limited time we strive to develop features of the future instead of supporting the past. <x id="CLOSE_PARAGRAPH"/><x id="START_PARAGRAPH"/> Please change to a more modern browser: <x id="START_LINK_1"/>Chrome<x id="CLOSE_LINK"/>, <x id="START_LINK_2"/>Firefox<x id="CLOSE_LINK"/>, <x id="START_LINK_3"/>Edge<x id="CLOSE_LINK"/>, <x id="START_LINK_4"/>Safari<x id="CLOSE_LINK"/>. <x id="CLOSE_PARAGRAPH"/></target>
         <note priority="1" from="description">Content</note>
         <note priority="1" from="meaning">IeWarningComponent</note>
       </trans-unit>
       <trans-unit id="IeWarningComponentButton" datatype="html">
         <source> I still want to use Internet Explorer! </source>
+        <target> I still want to use Internet Explorer! </target>
         <note priority="1" from="description">Button</note>
         <note priority="1" from="meaning">IeWarningComponent</note>
       </trans-unit>
       <trans-unit id="Headline" datatype="html">
         <source>Incorrect User Information</source>
+        <target>Incorrect User Information</target>
         <note priority="1" from="description">Headline</note>
         <note priority="1" from="meaning">User-InformationDialog</note>
       </trans-unit>
       <trans-unit id="GotItButton" datatype="html">
         <source> Got it! </source>
+        <target> Got it! </target>
         <note priority="1" from="description">Button</note>
         <note priority="1" from="meaning">User-InformationDialog</note>
       </trans-unit>
       <trans-unit id="Your Profile" datatype="html">
         <source> Dear <x id="INTERPOLATION"/>,<x id="LINE_BREAK"/> unfortunately, you can&apos;t change your user information via the Phonebook interface. <x id="LINE_BREAK"/> If your data is incorrect, please contact your Human Resources department. </source>
+        <target> Dear <x id="INTERPOLATION"/>,<x id="LINE_BREAK"/> unfortunately, you can&apos;t change your user information via the Phonebook interface. <x id="LINE_BREAK"/> If your data is incorrect, please contact your Human Resources department. </target>
         <note priority="1" from="description">Profile</note>
         <note priority="1" from="meaning">User-InformationDialog</note>
       </trans-unit>
       <trans-unit id="Colleague Profile" datatype="html">
         <source> Is there something wrong with the profile? <x id="LINE_BREAK"/> Please let your colleague know that the data is incorrect and that it can be changed through your Human Resources department. </source>
+        <target> Is there something wrong with the profile? <x id="LINE_BREAK"/> Please let your colleague know that the data is incorrect and that it can be changed through your Human Resources department. </target>
         <note priority="1" from="description">Profile</note>
         <note priority="1" from="meaning">User-InformationDialog</note>
       </trans-unit>
       <trans-unit id="SendEmail" datatype="html">
         <source>Send your colleague a direct message</source>
+        <target>Send your colleague a direct message</target>
         <note priority="1" from="description">Button</note>
         <note priority="1" from="meaning">User-InformationDialog</note>
       </trans-unit>
       <trans-unit id="Notify" datatype="html">
         <source>Notify <x id="INTERPOLATION"/></source>
+        <target>Notify <x id="INTERPOLATION"/></target>
         <note priority="1" from="description">Profile</note>
         <note priority="1" from="meaning">User-InformationDialog</note>
       </trans-unit>
       <trans-unit id="User-InformationDialogSubject" datatype="html">
         <source>There is an Issue with your Phonebook-Profile</source>
+        <target>There is an Issue with your Phonebook-Profile</target>
         <note priority="1" from="description">Send a mail to your mate if there is something wrong on the profile </note>
         <note priority="1" from="meaning">MailToMateSubject</note>
       </trans-unit>
       <trans-unit id="User-InformationDialogGreeting" datatype="html">
         <source>Hi </source>
+        <target>Hi </target>
         <note priority="1" from="description">Send a mail to your mate if there is something wrong on the profile </note>
         <note priority="1" from="meaning">MailToMateGreeting</note>
       </trans-unit>
@@ -818,81 +979,98 @@
         <source>, 
 while browsing your profile I noticed that something is not right: 
 Please contact the HR Department to fix it.This is the Phonebook Link: </source>
+        <target>, 
+while browsing your profile I noticed that something is not right: 
+Please contact the HR Department to fix it.This is the Phonebook Link: </target>
         <note priority="1" from="description">Send a mail to your mate if there is something wrong on the profile </note>
         <note priority="1" from="meaning">MailToMateBody</note>
       </trans-unit>
       <trans-unit id="GeneralCopyButton" datatype="html">
         <source>Copy to clipboard</source>
+        <target>Copy to clipboard</target>
         <note priority="1" from="description">Copy to Clipboard button</note>
         <note priority="1" from="meaning">GeneralCopyButton</note>
       </trans-unit>
       <trans-unit id="GeneralMailButton" datatype="html">
         <source>Send an Email</source>
+        <target>Send an Email</target>
         <note priority="1" from="description">Send Mail button</note>
         <note priority="1" from="meaning">GeneralMailButton</note>
       </trans-unit>
       <trans-unit id="GeneralCallButton" datatype="html">
         <source>Call the Number</source>
+        <target>Call the Number</target>
         <note priority="1" from="description">call Number button</note>
         <note priority="1" from="meaning">GeneralCallButton</note>
       </trans-unit>
       <trans-unit id="GeneralSuccessMessageCopy" datatype="html">
         <source>Copied to clipboard!</source>
+        <target>Copied to clipboard!</target>
         <note priority="1" from="description">Message displayed when copying a link is successfully</note>
         <note priority="1" from="meaning">GeneralSuccessMessageCopy</note>
       </trans-unit>
       <trans-unit id="GeneralErrorMessageCopy" datatype="html">
         <source>Couldn&apos;t copy to the clipboard, something went wrong. Try again.</source>
+        <target>Couldn&apos;t copy to the clipboard, something went wrong. Try again.</target>
         <note priority="1" from="description">Message displayed if something was not copied succesfully</note>
         <note priority="1" from="meaning">ErrorMessageCopy</note>
       </trans-unit>
       <trans-unit id="FeedbackDrawerSheetComponentTitle" datatype="html">
         <source> Leave Feedback, report a Bug or suggest a new Idea </source>
+        <target> Leave Feedback, report a Bug or suggest a new Idea </target>
         <note priority="1" from="description">Title of the Feedback Drawer</note>
         <note priority="1" from="meaning">FeedbackDrawerSheetComponent</note>
       </trans-unit>
       <trans-unit id="FeedbackDrawerSheetComponentButtonPublicGithubFeature" datatype="html">
         <source>Suggest an idea or a new feature</source>
+        <target>Suggest an idea or a new feature</target>
         <note priority="1" from="description">Button for suggesting a new feature on
           Github</note>
         <note priority="1" from="meaning">FeedbackDrawerSheetComponent</note>
       </trans-unit>
       <trans-unit id="FeedbackDrawerSheetComponentButtonPublicGithubBug" datatype="html">
         <source>Report a bug</source>
+        <target>Report a bug</target>
         <note priority="1" from="description">Button for reporting a bug on
           Github</note>
         <note priority="1" from="meaning">FeedbackDrawerSheetComponent</note>
       </trans-unit>
       <trans-unit id="FeedbackDrawerSheetComponentButtonPrivateOrganizationMail" datatype="html">
         <source>Contact your private organization via email</source>
+        <target>Contact your private organization via email</target>
         <note priority="1" from="description">Button for contacting the private Organization via
           email</note>
         <note priority="1" from="meaning">FeedbackDrawerSheetComponent</note>
       </trans-unit>
       <trans-unit id="FeedbackDrawerSheetComponentButtonPrivateOrganization" datatype="html">
         <source>Contact your private organization</source>
+        <target>Contact your private organization</target>
         <note priority="1" from="description">Button for contacting the private
           Organization</note>
         <note priority="1" from="meaning">FeedbackDrawerSheetComponent</note>
       </trans-unit>
       <trans-unit id="OrganigramNodeComponentPropertySupervisor" datatype="html">
         <source>{VAR_PLURAL, plural, =0 {No Supervisor } =1 {Supervisor: } other {Supervisors: }}</source>
+        <target>{VAR_PLURAL, plural, =0 {No Supervisor } =1 {Supervisor: } other {Supervisors: }}</target>
         <note priority="1" from="description">Supervisor Property</note>
         <note priority="1" from="meaning">OrganigramNodeComponent</note>
       </trans-unit>
       <trans-unit id="OrganigramNodeComponentPropertyAssistant" datatype="html">
         <source>{VAR_PLURAL, plural, =0 {No Assistant } =1 {Assistant: } other {Assistants: }}</source>
+        <target>{VAR_PLURAL, plural, =0 {No Assistant } =1 {Assistant: } other {Assistants: }}</target>
         <note priority="1" from="description">Assistant Property</note>
         <note priority="1" from="meaning">OrganigramNodeComponent</note>
       </trans-unit>
       <trans-unit id="OrganigramNodeComponentExpandAriaLabel" datatype="html">
         <source>Button expanding or collapsing this node. </source>
+        <target>Button expanding or collapsing this node. </target>
         <note priority="1" from="description">Aria Label for expand Button on Organigram
           Node</note>
         <note priority="1" from="meaning">OrganigramNodeComponent</note>
       </trans-unit>
       <trans-unit id="OrganigramNodeComponentExpandTooltip" datatype="html">
         <source>Expand or Collapse this node.</source>
+        <target>Expand or Collapse this node.</target>
         <note priority="1" from="description">Tooltip for expanding a Organigram
           Node</note>
         <note priority="1" from="meaning">OrganigramNodeComponent</note>
@@ -900,237 +1078,338 @@ Please contact the HR Department to fix it.This is the Phonebook Link: </source>
       <trans-unit id="OrganigramNodeComponentPropertyEmployee" datatype="html">
         <source>{VAR_PLURAL, plural, =0 {No Employees } =1 {Employee: } other {Employees:
             }}</source>
+        <target>{VAR_PLURAL, plural, =0 {No Employees } =1 {Employee: } other {Employees:
+            }}</target>
         <note priority="1" from="description">Employee Property</note>
         <note priority="1" from="meaning">OrganigramNodeComponent</note>
       </trans-unit>
       <trans-unit id="OrganigramNodeComponentPropertyLearner" datatype="html">
         <source>{VAR_PLURAL, plural, =0 {No Learners } =1 {Learner: } other {Learners:
             }}</source>
+        <target>{VAR_PLURAL, plural, =0 {No Learners } =1 {Learner: } other {Learners:
+            }}</target>
         <note priority="1" from="description">Learners Property</note>
         <note priority="1" from="meaning">OrganigramNodeComponent</note>
       </trans-unit>
       <trans-unit id="OrganigramNodeComponentCopiedFirstPart" datatype="html">
         <source>Link to</source>
+        <target>Link to</target>
         <note priority="1" from="description">First part of the message displayed when copying a link to the node</note>
         <note priority="1" from="meaning">OrganigramNodeComponent</note>
       </trans-unit>
       <trans-unit id="OrganigramNodeComponentCopiedSecondPart" datatype="html">
         <source>copied to clipboard!</source>
+        <target>copied to clipboard!</target>
         <note priority="1" from="description">Second part of the message displayed when copying a link to the node</note>
         <note priority="1" from="meaning">OrganigramNodeComponent</note>
       </trans-unit>
+      <trans-unit id="NodeComponentPropertySupervisor" datatype="html">
+        <source>{VAR_PLURAL, plural, =0 {No Supervisor } =1 {Supervisor: } other {Supervisors: }}</source>
+        <target>{VAR_PLURAL, plural, =0 {No Supervisor } =1 {Supervisor: } other {Supervisors: }}</target>
+        <note priority="1" from="description">Supervisor Property</note>
+        <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit>
+      <trans-unit id="NodeComponentPropertyAssistant" datatype="html">
+        <source>{VAR_PLURAL, plural, =0 {No Assistant } =1 {Assistant: } other {Assistants:
+        }}</source>
+        <target>{VAR_PLURAL, plural, =0 {No Assistant } =1 {Assistant: } other {Assistants:
+        }}</target>
+        <note priority="1" from="description">Assistant Property</note>
+        <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit>
+      <trans-unit id="NodeComponentPropertyEmployee" datatype="html">
+        <source>{VAR_PLURAL, plural, =0 {No Employees } =1 {Employee: } other {Employees:
+          }}</source>
+        <target>{VAR_PLURAL, plural, =0 {No Employees } =1 {Employee: } other {Employees:
+          }}</target>
+        <note priority="1" from="description">Employee Property</note>
+        <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit>
+      <trans-unit id="NodeComponentPropertyLearner" datatype="html">
+        <source>{VAR_PLURAL, plural, =0 {No Learners } =1 {Learner: } other {Learners:
+          }}</source>
+        <target>{VAR_PLURAL, plural, =0 {No Learners } =1 {Learner: } other {Learners:
+          }}</target>
+        <note priority="1" from="description">Learners Property</note>
+        <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit>
+      <trans-unit id="CityComponentErrorNoCity" datatype="html">
+        <source>City does not exist.</source>
+        <target>City does not exist.</target>
+        <note priority="1" from="description">Error Message if City does not exist.</note>
+        <note priority="1" from="meaning">CityComponent</note>
+      </trans-unit>
+      <trans-unit id="OrganigramComponentButtonExpandAriaLabel" datatype="html">
+        <source>Button expanding or collapsing the tree view on the left.</source>
+        <target>Button expanding or collapsing the tree view on the left.</target>
+        <note priority="1" from="description">Aria Label for expanding the tree
+          view</note>
+        <note priority="1" from="meaning">OrganigramComponent</note>
+      </trans-unit>
+      <trans-unit id="OrganigramComponentButtonExpandTooltip" datatype="html">
+        <source>Expand or Collapse the tree view.</source>
+        <target>Expand or Collapse the tree view.</target>
+        <note priority="1" from="description">Tooltip for expanding the tree
+          view</note>
+        <note priority="1" from="meaning">OrganigramComponent</note>
+      </trans-unit>
+      <trans-unit id="OrganigramComponentRootNavigationTitle" datatype="html">
+        <source>Overview</source>
+        <target>Overview</target>
+        <note priority="1" from="description">Root of the Organigram Tree</note>
+        <note priority="1" from="meaning">OrganigramComponent</note>
+      </trans-unit>
+      <trans-unit id="OrganigramComponentWhoAmI" datatype="html">
+        <source> Where am I? </source>
+        <target> Where am I? </target>
+        <note priority="1" from="description">Button for going to user&apos;s organigram</note>
+        <note priority="1" from="meaning">OrganigramComponent</note>
+      </trans-unit>
       <trans-unit id="DataLocationAddress" datatype="html">
         <source> Address </source>
+        <target> Address </target>
         <note priority="1" from="description">Label for address</note>
         <note priority="1" from="meaning">Datapoint</note>
       </trans-unit>
       <trans-unit id="DataLocationContact" datatype="html">
         <source> Contact </source>
+        <target> Contact </target>
         <note priority="1" from="description">Label for contact information</note>
         <note priority="1" from="meaning">Datapoint</note>
       </trans-unit>
       <trans-unit id="DataPersonFloorPlural" datatype="html">
         <source> Floors </source>
+        <target> Floors </target>
         <note priority="1" from="description">Floor plural</note>
         <note priority="1" from="meaning">Datapoint</note>
       </trans-unit>
       <trans-unit id="GeneralShowOnMapButton" datatype="html">
         <source>Show on Google-Maps</source>
+        <target>Show on Google-Maps</target>
         <note priority="1" from="description">Button label for showing the location on google maps</note>
         <note priority="1" from="meaning">General</note>
       </trans-unit>
       <trans-unit id="DataLocationContactPerson" datatype="html">
         <source> Contact Person </source>
+        <target> Contact Person </target>
         <note priority="1" from="description">Label for Location.ContactPerson</note>
         <note priority="1" from="meaning">Datapoint</note>
       </trans-unit>
       <trans-unit id="BuildingComponentErrorNoBuilding" datatype="html">
         <source>Building does not exist.</source>
+        <target>Building does not exist.</target>
         <note priority="1" from="description">Error Message if Building does not exist.</note>
         <note priority="1" from="meaning">BuildingComponent</note>
       </trans-unit>
       <trans-unit id="CityComponentSubHeaderLocation" datatype="html">
         <source> Buildings </source>
+        <target> Buildings </target>
         <note priority="1" from="description">Subheader for all building locations in the
           city</note>
         <note priority="1" from="meaning">CityComponent</note>
       </trans-unit>
-      <trans-unit id="CityComponentErrorNoCity" datatype="html">
-        <source>City does not exist.</source>
-        <note priority="1" from="description">Error Message if City does not exist.</note>
-        <note priority="1" from="meaning">CityComponent</note>
-      </trans-unit>
       <trans-unit id="FloorComponentSubHeaderRooms" datatype="html">
         <source> Rooms </source>
+        <target> Rooms </target>
         <note priority="1" from="description">SubHeader for all Rooms in the floor</note>
         <note priority="1" from="meaning">FloorComponent</note>
       </trans-unit>
       <trans-unit id="FloorComponentErrorNoFloor" datatype="html">
         <source>Floor does not exist.</source>
+        <target>Floor does not exist.</target>
         <note priority="1" from="description">Error Message if Floor does not exist.</note>
         <note priority="1" from="meaning">FloorComponent</note>
       </trans-unit>
       <trans-unit id="RoomTreeComponentButtonExpandAriaLabel" datatype="html">
         <source>Button expanding or collapsing the tree view on the left.</source>
+        <target>Button expanding or collapsing the tree view on the left.</target>
         <note priority="1" from="description">Aria Label for expanding the tree
           view</note>
         <note priority="1" from="meaning">RoomTreeComponent</note>
       </trans-unit>
       <trans-unit id="RoomTreeComponentButtonExpandTooltip" datatype="html">
         <source>Expand or Collapse the tree view.</source>
+        <target>Expand or Collapse the tree view.</target>
         <note priority="1" from="description">Tooltip for expanding the tree
           view</note>
         <note priority="1" from="meaning">RoomTreeComponent</note>
       </trans-unit>
       <trans-unit id="RoomTreeComponentRootNavigationTitle" datatype="html">
         <source>Overview</source>
+        <target>Overview</target>
         <note priority="1" from="description">Root of the Navigation Tree</note>
         <note priority="1" from="meaning">Room-treeComponent</note>
       </trans-unit>
       <trans-unit id="RoomTreeComponentButtonBookingTool" datatype="html">
         <source> Booking Tool </source>
+        <target> Booking Tool </target>
         <note priority="1" from="description">Button for changing to the booking
         tool</note>
         <note priority="1" from="meaning">RoomTreeComponent</note>
       </trans-unit>
       <trans-unit id="RoomDetailComponentShareButtonTooltip" datatype="html">
         <source>Share this room.</source>
+        <target>Share this room.</target>
         <note priority="1" from="description">Tooltip for the Room sharing
           button</note>
         <note priority="1" from="meaning">RoomDetailComponent</note>
       </trans-unit>
       <trans-unit id="RoomDetailComponentShareButtonAriaLabel" datatype="html">
         <source>Button for sharing this room.</source>
+        <target>Button for sharing this room.</target>
         <note priority="1" from="description">Aria Label for sharing the
           room</note>
         <note priority="1" from="meaning">RoomDetailComponent</note>
       </trans-unit>
       <trans-unit id="RoomDetailComponentShareButtonLinkOption" datatype="html">
         <source>Link</source>
+        <target>Link</target>
         <note priority="1" from="description">Option for getting a Link to the
               Room</note>
         <note priority="1" from="meaning">RoomDetailComponent</note>
       </trans-unit>
       <trans-unit id="RoomDetailComponentShareButtonMailOption" datatype="html">
         <source>Share by mail</source>
+        <target>Share by mail</target>
         <note priority="1" from="description">Option for sharing the room by
               Mail</note>
         <note priority="1" from="meaning">RoomDetailComponent</note>
       </trans-unit>
       <trans-unit id="RoomDetailComponentMainTitle" datatype="html">
         <source> Information </source>
+        <target> Information </target>
         <note priority="1" from="description">Title for the main information of the
             room</note>
         <note priority="1" from="meaning">RoomDetailComponent</note>
       </trans-unit>
       <trans-unit id="RoomDetailComponentSubTitleLocation" datatype="html">
         <source> Location </source>
+        <target> Location </target>
         <note priority="1" from="description">Subtitle for the location information of the
               room</note>
         <note priority="1" from="meaning">RoomDetailComponent</note>
       </trans-unit>
       <trans-unit id="RoomComponentSubTitleInThisRoom" datatype="html">
         <source> In this Room </source>
+        <target> In this Room </target>
         <note priority="1" from="description">Title for the subtitle about the people in this
             room</note>
         <note priority="1" from="meaning">RoomDetailComponent</note>
       </trans-unit>
       <trans-unit id="RoomDetailComponentSubTitleCommunication" datatype="html">
         <source> Phone Number </source>
+        <target> Phone Number </target>
         <note priority="1" from="description">Subtitle for the communication information of the
               room</note>
         <note priority="1" from="meaning">RoomDetailComponent</note>
       </trans-unit>
       <trans-unit id="RoomComponentDescriptionNoPersons" datatype="html">
         <source> Nobody works in this room. </source>
+        <target> Nobody works in this room. </target>
         <note priority="1" from="description">Message displayed if no people are in the
               room</note>
         <note priority="1" from="meaning">DashboardComponent</note>
       </trans-unit>
       <trans-unit id="RoomComponentErrorNoRoom" datatype="html">
         <source>Room does not exist.</source>
+        <target>Room does not exist.</target>
         <note priority="1" from="description">Error Message if Room does not exist.</note>
         <note priority="1" from="meaning">RoomComponent</note>
       </trans-unit>
       <trans-unit id="RoomDetailComponentMailSubject" datatype="html">
         <source>Information about the room: </source>
+        <target>Information about the room: </target>
         <note priority="1" from="description">subject of the email message that is preset when clicking &quot;Share by mail&quot;. The room is applied after this sentence.</note>
         <note priority="1" from="meaning">RoomDetailComponent</note>
       </trans-unit>
       <trans-unit id="RoomDetailComponentMailBodyPart1" datatype="html">
         <source>Here is the Link: </source>
+        <target>Here is the Link: </target>
         <note priority="1" from="description">the body of the email that is preset when clicking &quot;Share by mail&quot;. The link to the room is applied after this sentence.</note>
         <note priority="1" from="meaning">RoomDetailComponent</note>
       </trans-unit>
       <trans-unit id="PageInformationComponentTitle" datatype="html">
         <source> Phonebook </source>
+        <target> Phonebook </target>
         <note priority="1" from="description">Title of the page information</note>
         <note priority="1" from="meaning">PageInformationComponent</note>
       </trans-unit>
       <trans-unit id="PageInformationComponentSubTitleFeedback" datatype="html">
         <source> Contact &amp; Feedback </source>
+        <target> Contact &amp; Feedback </target>
         <note priority="1" from="description">Subtitle for Contact and
               Feedback</note>
         <note priority="1" from="meaning">Page-informationComponent</note>
       </trans-unit>
       <trans-unit id="PageInformationComponentSectionFeedbackButton" datatype="html">
         <source>Contact us</source>
+        <target>Contact us</target>
         <note priority="1" from="description">Feedback
               Button</note>
         <note priority="1" from="meaning">Page-informationComponent</note>
       </trans-unit>
       <trans-unit id="PageInformationComponentSubTitleUserGuide" datatype="html">
         <source> User Guide </source>
+        <target> User Guide </target>
         <note priority="1" from="description">Subtitle for User
               Guide</note>
         <note priority="1" from="meaning">Page-informationComponent</note>
       </trans-unit>
       <trans-unit id="PageInformationComponentSectionUserGuide" datatype="html">
         <source><x id="START_TAG_SPAN"/> Are you new to the Phonebook? Do you have any questions? Then visit the Phonebook&apos;s User Guide. It explains all its features and possibilities. <x id="CLOSE_TAG_SPAN"/></source>
+        <target><x id="START_TAG_SPAN"/> Are you new to the Phonebook? Do you have any questions? Then visit the Phonebook&apos;s User Guide. It explains all its features and possibilities. <x id="CLOSE_TAG_SPAN"/></target>
         <note priority="1" from="description">User Guide Section</note>
         <note priority="1" from="meaning">Page-informationComponent</note>
       </trans-unit>
       <trans-unit id="PageInformationComponentSectionUserGuideButton" datatype="html">
         <source>Open User Guide</source>
+        <target>Open User Guide</target>
         <note priority="1" from="description">User Guide
               Button</note>
         <note priority="1" from="meaning">Page-informationComponent</note>
       </trans-unit>
       <trans-unit id="PageInformationComponentSubTitleCookie" datatype="html">
         <source> Cookie Notice </source>
+        <target> Cookie Notice </target>
         <note priority="1" from="description">Subtitle for Cookie</note>
         <note priority="1" from="meaning">Page-informationComponent</note>
       </trans-unit>
       <trans-unit id="PageInformationComponentSectionCookies" datatype="html">
         <source> This site uses cookies, to enhance your experience. Cookies are only used for necessary tasks, e.g. saving the language you want to use. </source>
+        <target> This site uses cookies, to enhance your experience. Cookies are only used for necessary tasks, e.g. saving the language you want to use. </target>
         <note priority="1" from="description">CookiesSection</note>
         <note priority="1" from="meaning">Page-informationComponent</note>
       </trans-unit>
       <trans-unit id="PageInformationComponentSubTitleLicenses" datatype="html">
         <source> Licenses </source>
+        <target> Licenses </target>
         <note priority="1" from="description">Subtitle for
               Licenses</note>
         <note priority="1" from="meaning">Page-informationComponent</note>
       </trans-unit>
       <trans-unit id="PageInformationComponentSubTitleLicensesText" datatype="html">
         <source> This Project is licensed under the <x id="START_LINK"/>MIT License<x id="CLOSE_LINK"/>. Other licenses from modules and packets may apply. </source>
+        <target> This Project is licensed under the <x id="START_LINK"/>MIT License<x id="CLOSE_LINK"/>. Other licenses from modules and packets may apply. </target>
         <note priority="1" from="description">Text for Licenses
             SubTitle</note>
         <note priority="1" from="meaning">Page-informationComponent</note>
       </trans-unit>
       <trans-unit id="PageInformationComponentSubTitleAttributions" datatype="html">
         <source> Icon of the Phonebook made by <x id="START_LINK"/>Gregor Cresnar<x id="CLOSE_LINK"/> from <x id="START_LINK_1"/>www.flaticon.com<x id="CLOSE_LINK"/> is licensed by <x id="START_LINK_2"/>CC 3.0 BY<x id="CLOSE_LINK"/></source>
+        <target> Icon of the Phonebook made by <x id="START_LINK"/>Gregor Cresnar<x id="CLOSE_LINK"/> from <x id="START_LINK_1"/>www.flaticon.com<x id="CLOSE_LINK"/> is licensed by <x id="START_LINK_2"/>CC 3.0 BY<x id="CLOSE_LINK"/></target>
         <note priority="1" from="description">Attributions
             SubTitle</note>
         <note priority="1" from="meaning">Page-informationComponent</note>
       </trans-unit>
       <trans-unit id="PageInformationComponentDisclaimer" datatype="html">
         <source> This is a Preview application. We are doing our best not to break anything, but we can&apos;t guarantee. Thats why all Features are still subject to change without further notice and your data may get lost. </source>
+        <target> This is a Preview application. We are doing our best not to break anything, but we can&apos;t guarantee. Thats why all Features are still subject to change without further notice and your data may get lost. </target>
         <note priority="1" from="description">Disclaimer beneath title</note>
         <note priority="1" from="meaning">Page-informationComponent</note>
       </trans-unit>
       <trans-unit id="PageInformationComponentSectionFeedback" datatype="html">
         <source><x id="START_TAG_SPAN"/> This is an Installation of the Open Source Phonebook. <x id="CLOSE_TAG_SPAN"/><x id="START_TAG_SPAN_1"/> You can contact your own support at <x id="START_LINK"/><x id="INTERPOLATION"/><x id="CLOSE_LINK"/> regarding this installation. <x id="CLOSE_TAG_SPAN"/><x id="START_TAG_SPAN"/> You&apos;ve found a bug or have an idea for a new feature? <x id="CLOSE_TAG_SPAN"/></source>
+        <target><x id="START_TAG_SPAN"/> This is an Installation of the Open Source Phonebook. <x id="CLOSE_TAG_SPAN"/><x id="START_TAG_SPAN_1"/> You can contact your own support at <x id="START_LINK"/><x id="INTERPOLATION"/><x id="CLOSE_LINK"/> regarding this installation. <x id="CLOSE_TAG_SPAN"/><x id="START_TAG_SPAN"/> You&apos;ve found a bug or have an idea for a new feature? <x id="CLOSE_TAG_SPAN"/></target>
         <note priority="1" from="description">Feedback Section</note>
         <note priority="1" from="meaning">Page-informationComponent</note>
       </trans-unit>

--- a/Phonebook.Frontend/src/i18n/messages.xlf
+++ b/Phonebook.Frontend/src/i18n/messages.xlf
@@ -1133,11 +1133,23 @@ Please contact the HR Department to fix it.This is the Phonebook Link: </target>
         <note priority="1" from="description">Learners Property</note>
         <note priority="1" from="meaning">NodeComponent</note>
       </trans-unit>
-      <trans-unit id="CityComponentErrorNoCity" datatype="html">
-        <source>City does not exist.</source>
-        <target>City does not exist.</target>
-        <note priority="1" from="description">Error Message if City does not exist.</note>
-        <note priority="1" from="meaning">CityComponent</note>
+      <trans-unit id="NodeComponentErrorNoNode" datatype="html">
+        <source>Organisation does not exist.</source>
+        <target>Organisation does not exist.</target>
+        <note priority="1" from="description">Error Message if Node does not exist.</note>
+        <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit>
+      <trans-unit id="NodeComponentCopiedFirstPart" datatype="html">
+        <source>Link to</source>
+        <target>Link to</target>
+        <note priority="1" from="description">First part of the message displayed when copying a link to the node</note>
+        <note priority="1" from="meaning">NodeComponent</note>
+      </trans-unit>
+      <trans-unit id="NodeComponentCopiedSecondPart" datatype="html">
+        <source>copied to clipboard!</source>
+        <target>copied to clipboard!</target>
+        <note priority="1" from="description">Second part of the message displayed when copying a link to the node</note>
+        <note priority="1" from="meaning">NodeComponent</note>
       </trans-unit>
       <trans-unit id="OrganigramComponentButtonExpandAriaLabel" datatype="html">
         <source>Button expanding or collapsing the tree view on the left.</source>
@@ -1206,6 +1218,12 @@ Please contact the HR Department to fix it.This is the Phonebook Link: </target>
         <target> Buildings </target>
         <note priority="1" from="description">Subheader for all building locations in the
           city</note>
+        <note priority="1" from="meaning">CityComponent</note>
+      </trans-unit>
+      <trans-unit id="CityComponentErrorNoCity" datatype="html">
+        <source>City does not exist.</source>
+        <target>City does not exist.</target>
+        <note priority="1" from="description">Error Message if City does not exist.</note>
         <note priority="1" from="meaning">CityComponent</note>
       </trans-unit>
       <trans-unit id="FloorComponentSubHeaderRooms" datatype="html">


### PR DESCRIPTION
Now the organigram looks and works like the rooms. With the current mock backend everything should be working. However, the mock backend doesn't have any children. I'm currently working on adding children and implementing that into the page.

If you have any suggestions as to how we could name the children, that would be very helpful. At the moment the heading would say Sub-Groups:/Untergruppen: